### PR TITLE
fix: rebase when pulling

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -4,7 +4,7 @@ COMPONENTS := $(wildcard components/*)
 CWD := $(shell pwd)
 
 checkout:
-	git pull
+	git pull --rebase
 	git submodule update --init
 
 node:


### PR DESCRIPTION
Avoids this warning in newer versions of git:

```
warning: Pulling without specifying how to reconcile divergent branches is
discouraged. You can squelch this message by running one of the following
commands sometime before your next pull:

  git config pull.rebase false  # merge (the default strategy)
  git config pull.rebase true   # rebase
  git config pull.ff only       # fast-forward only

You can replace "git config" with "git config --global" to set a default
preference for all repositories. You can also pass --rebase, --no-rebase,
or --ff-only on the command line to override the configured default per
invocation.
```