### PR TITLE
fix: reference `read-vx-machine-config.sh` correctly

### DIFF
--- a/run-election-manager.sh
+++ b/run-election-manager.sh
@@ -1,10 +1,12 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 # go to directory where this file is located
 cd "$(dirname "$0")"
 
 # configuration information
-source config/admin-functions/read-vx-machine-config.sh
+source config/read-vx-machine-config.sh
 
 export PIPENV_VENV_IN_PROJECT=1
 (trap 'kill 0' SIGINT SIGHUP; make -C frontends/election-manager run)


### PR DESCRIPTION
I added the "strict mode" directive so this kind of silent failure won't happen again. We should add that to the other scripts later, make them executable, and change the invocations to just run them directly rather than `bash run-election-manager.sh`. Either that or remove the shebang line.