### PR TITLE
add environment variables and config stuff that didn't get ported over.

### DIFF
--- a/config/vx-ballot-scanner.service
+++ b/config/vx-ballot-scanner.service
@@ -4,6 +4,7 @@ Description=VotingWorks Ballot Scanner
 [Service]
 Type=simple
 User=vx-services
+Environment=VX_CONFIG_ROOT=/vx-config
 ExecStart=/bin/bash /vx-services/run-bsd.sh
 StandardOutput=syslog
 StandardError=syslog

--- a/config/vx-election-manager.service
+++ b/config/vx-election-manager.service
@@ -4,6 +4,7 @@ Description=VotingWorks Election Manager
 [Service]
 Type=simple
 User=vx-services
+Environment=VX_CONFIG_ROOT=/vx-config
 ExecStart=/bin/bash /vx-services/run-election-manager.sh
 StandardOutput=syslog
 StandardError=syslog

--- a/run-bsd.sh
+++ b/run-bsd.sh
@@ -3,5 +3,10 @@
 # go to directory where this file is located
 cd "$(dirname "$0")"
 
+: "${VX_CONFIG_ROOT:="./config"}"
+
+# configuration information
+source ${VX_CONFIG_ROOT}/read-vx-machine-config.sh
+
 export PIPENV_VENV_IN_PROJECT=1
 (trap 'kill 0' SIGINT SIGHUP; make -C components/module-scan run & make -C frontends/bsd run)

--- a/run-election-manager.sh
+++ b/run-election-manager.sh
@@ -5,8 +5,10 @@ set -euo pipefail
 # go to directory where this file is located
 cd "$(dirname "$0")"
 
+: "${VX_CONFIG_ROOT:="./config"}"
+
 # configuration information
-source config/read-vx-machine-config.sh
+source ${VX_CONFIG_ROOT}/read-vx-machine-config.sh
 
 export PIPENV_VENV_IN_PROJECT=1
 (trap 'kill 0' SIGINT SIGHUP; make -C frontends/election-manager run)


### PR DESCRIPTION

Installation of BSD and EM had regressed because of changes I made to BMD / BAS installation that I didn't carry over. Fixing that here.