### PR TITLE
Increase cursor size

### DIFF
--- a/config/Xresources
+++ b/config/Xresources
@@ -1,0 +1,1 @@
+Xcursor.size: 32

--- a/config/xinitrc
+++ b/config/xinitrc
@@ -1,6 +1,7 @@
 xset -dpms
 xset s off
 xset s noblank
+xrdb ~/.Xresources
 
 bash /vx-ui/.vx/run-kiosk-browser-forever-and-log.sh &
 

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -109,6 +109,7 @@ sudo cp run-kiosk-browser-forever-and-log.sh /vx-ui/.vx/
 # copy the .bash_profile and .xinitrc for vx-ui auto start
 sudo cp config/ui_bash_profile /vx-ui/.bash_profile
 
+sudo cp config/Xresources /vx-ui/.Xresources
 sudo cp config/xinitrc /vx-ui/.xinitrc
 
 # admin function scripts


### PR DESCRIPTION
Increases the size of the cursor to 32px from the default of 16px. 

Before: 
<img width="1019" alt="cursorsizedefault" src="https://user-images.githubusercontent.com/14897017/99324331-d149a700-2828-11eb-9fe1-3979c7fe755a.png">

After: 
<img width="1028" alt="cursorsize32" src="https://user-images.githubusercontent.com/14897017/99324336-d27ad400-2828-11eb-9daf-c118137e95ef.png">

For context in case we want to go even bigger this is what 64px looks like: 
<img width="1018" alt="curssorsize64" src="https://user-images.githubusercontent.com/14897017/99324343-d60e5b00-2828-11eb-8b5f-79f1a592c396.png">

Tested by running the setup-machine script on a fresh ubuntu virtual machine and setting up as election manager and verifying the cursor size changed and persisted when opening file pickers, etc. I noticed (even without these changes) the cursor also exists when set up as bmd, I assume the touch screen laptops somehow remove the cursor outside of what I can test on my VM but I wasn't sure exactly how that works. 


