### PR TITLE
Fix removing ubuntu desktop

### DIFF
--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -211,7 +211,7 @@ echo "Successfully setup machine."
 USER=$(whoami)
 
 # remove all unnecessary packages
-sudo apt remove -y --auto-remove ubuntu-gnome-desktop
+sudo apt remove -y ubuntu-desktop
 sudo apt remove -y git firefox snapd
 sudo apt autoremove -y
 


### PR DESCRIPTION
Updates the sudo apt remove in the setup machine script to remove the correct package 'ubuntu-desktop' as 'ubuntu-gnome-desktop' does not exist. Also removed the --autoremove as the sudo apt autoremove two lines later sure take care of any auto removal needed. 

Tested booting in all 4 machine types and it booted fine. I wasn't sure how to test election configurations through booting this way though so the only one I really clicked around in was election-manager where I tested to make sure the file chooser dialog window still worked properly. 