### PR TITLE
Update kiosk browser file permissions to new format

### DIFF
--- a/run-kiosk-browser.sh
+++ b/run-kiosk-browser.sh
@@ -2,5 +2,5 @@
 
 URL=$1
 
-kiosk-browser --allowed-save-as-hostname-pattern localhost --allowed-save-as-destination-pattern "/media/**/*" --autoconfigure-print-config ./printing/printer-autoconfigure.json --url ${URL:-http://localhost:3000}
+kiosk-browser --add-file-perm o=http://localhost:*,p=/media/**/*,rw --autoconfigure-print-config ./printing/printer-autoconfigure.json --url ${URL:-http://localhost:3000}
 

--- a/run-kiosk-browser.sh
+++ b/run-kiosk-browser.sh
@@ -2,5 +2,5 @@
 
 URL=$1
 
-kiosk-browser --add-file-perm o=http://localhost:*,p=/media/**/*,rw --autoconfigure-print-config ./printing/printer-autoconfigure.json --url ${URL:-http://localhost:3000}
+kiosk-browser --add-file-perm o=http://localhost:3000,p=/media/**/*,rw --autoconfigure-print-config ./printing/printer-autoconfigure.json --url ${URL:-http://localhost:3000}
 


### PR DESCRIPTION
Updates how we run kiosk browser to use the new file permissions as updated in https://github.com/votingworks/kiosk-browser/pull/62. 

Tested by running setup-machine.sh for election-manager and bsd on the current main branch of vxsuite and reading/writing ballot package and CVR files on a USB successfully. 