### PR TITLE
fix: standardize run scripts

### DIFF
--- a/config/admin-functions/show-vx-suite-admin-menu.sh
+++ b/config/admin-functions/show-vx-suite-admin-menu.sh
@@ -3,7 +3,6 @@
 set -euo pipefail
 
 : "${VX_FUNCTIONS_ROOT:="$(dirname "$0")"}"
-: "${VX_CONFIG_ROOT:="/vx-config"}"
 
 prompt-to-restart() {
   read -s -e -n 1 -p "Success! You must reboot for this change to take effect. Reboot now? [Yn] "
@@ -13,7 +12,7 @@ prompt-to-restart() {
 }
 
 while true; do
-  source "${VX_CONFIG_ROOT}/read-vx-machine-config.sh"
+  source "${VX_FUNCTIONS_ROOT}/../read-vx-machine-config.sh"
   clear
 
   echo -e "\e[1mVxSuite Admin\e[0m"

--- a/run-bas.sh
+++ b/run-bas.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 # go to directory where this file is located
 cd "$(dirname "$0")"
 
-: "${VX_CONFIG_ROOT:="./config"}"
-
 # configuration information
-source ${VX_CONFIG_ROOT}/read-vx-machine-config.sh
+source config/read-vx-machine-config.sh
 
 export PIPENV_VENV_IN_PROJECT=1
+export NODE_ENV=production
 (trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/module-smartcards run & make -C vxsuite/apps/bas run)

--- a/run-bmd.sh
+++ b/run-bmd.sh
@@ -1,12 +1,13 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 # go to directory where this file is located
 cd "$(dirname "$0")"
 
-: "${VX_CONFIG_ROOT:="./config"}"
-
 # configuration information
-source ${VX_CONFIG_ROOT}/read-vx-machine-config.sh
+source config/read-vx-machine-config.sh
 
 export PIPENV_VENV_IN_PROJECT=1
+export NODE_ENV=production
 (trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/module-smartcards run & make -C vxsuite/apps/bmd run)

--- a/run-bsd.sh
+++ b/run-bsd.sh
@@ -1,16 +1,13 @@
 #!/usr/bin/env bash
 
+set -euo pipefail
+
 # go to directory where this file is located
 cd "$(dirname "$0")"
 
-: "${VX_CONFIG_ROOT:="./config"}"
-: "${VX_DATA_ROOT:="${HOME}/data"}"
-
 # configuration information
-source ${VX_CONFIG_ROOT}/read-vx-machine-config.sh
-
-export MODULE_SCAN_WORKSPACE="${VX_DATA_ROOT}/module-scan-workspace"
-mkdir -p "${MODULE_SCAN_WORKSPACE}"
+source config/read-vx-machine-config.sh
 
 export PIPENV_VENV_IN_PROJECT=1
+export NODE_ENV=production
 (trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/module-scan run & make -C vxsuite/apps/bsd run)

--- a/run-election-manager.sh
+++ b/run-election-manager.sh
@@ -5,10 +5,9 @@ set -euo pipefail
 # go to directory where this file is located
 cd "$(dirname "$0")"
 
-: "${VX_CONFIG_ROOT:="./config"}"
-
 # configuration information
-source ${VX_CONFIG_ROOT}/read-vx-machine-config.sh
+source config/read-vx-machine-config.sh
 
 export PIPENV_VENV_IN_PROJECT=1
+export NODE_ENV=production
 (trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/election-manager run)

--- a/run-kiosk-browser-forever-and-log.sh
+++ b/run-kiosk-browser-forever-and-log.sh
@@ -2,11 +2,11 @@
 
 set -euo pipefail
 
-# load configuration
-source /vx-config/read-vx-machine-config.sh
-
 # go to directory where this file is located
 cd "$(dirname "$0")"
+
+# configuration information
+source config/read-vx-machine-config.sh
 
 : "${VX_MACHINE_TYPE:=""}"
 

--- a/run-kiosk-browser.sh
+++ b/run-kiosk-browser.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+set -euo pipefail
+
 URL=$1
 
 kiosk-browser --add-file-perm o=http://localhost:3000,p=/media/**/*,rw --autoconfigure-print-config ./printing/printer-autoconfigure.json --url ${URL:-http://localhost:3000}


### PR DESCRIPTION
- `VX_CONFIG_ROOT` is not the `config` directory; it's where the config files are stored i.e. `/vx-config`
- add `set -euo pipefail` "strict mode" directive to scripts
- make `run-*.sh` scripts executable
- set `NODE_ENV=production`