### PR TITLE
feat: include date in code version

### DIFF
--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -146,8 +146,8 @@ sudo ln -s /vx/code/config/read-vx-machine-config.sh /vx/config/read-vx-machine-
 # record the machine type in the configuration (-E keeps the environment variable around, CHOICE prefix sends it in)
 CHOICE="${CHOICE}" sudo -E sh -c 'echo "${CHOICE}" > /vx/config/machine-type'
 
-# code version
-sudo sh -c 'git rev-parse HEAD > /vx/config/code-version'
+# code version, e.g. "2021.03.29-d34db33fcd"
+sudo sh -c 'echo "$(date +%Y.%m.%d)-$(git rev-parse HEAD | cut -c -10)" > /vx/config/code-version'
 
 # machine ID
 sudo sh -c 'echo "0000" > /vx/config/machine-id'


### PR DESCRIPTION
Instead of a full git SHA, it now shows the date plus the first 10 characters of the SHA e.g. "2021.03.29-d34db33fcd".

Refs votingworks/vxsuite#343