### PR TITLE
fix: warn on workspace missing

### DIFF
--- a/run-scripts/run-bsd.sh
+++ b/run-scripts/run-bsd.sh
@@ -9,6 +9,11 @@ cd "$(dirname "$0")"
 CONFIG=${VX_CONFIG_ROOT:-./config}
 source ${CONFIG}/read-vx-machine-config.sh
 
+if [ -z "${MODULE_SCAN_WORKSPACE:-}" ]; then
+  echo "error: please set MODULE_SCAN_WORKSPACE and try again" >&2
+  exit 1
+fi
+
 export PIPENV_VENV_IN_PROJECT=1
 export NODE_ENV=production
 (trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/module-scan run & make -C vxsuite/apps/bsd run)

--- a/run-scripts/run-precinct-scanner.sh
+++ b/run-scripts/run-precinct-scanner.sh
@@ -9,6 +9,11 @@ cd "$(dirname "$0")"
 CONFIG=${VX_CONFIG_ROOT:-./config}
 source ${CONFIG}/read-vx-machine-config.sh
 
+if [ -z "${MODULE_SCAN_WORKSPACE:-}" ]; then
+  echo "error: please set MODULE_SCAN_WORKSPACE and try again" >&2
+  exit 1
+fi
+
 export PIPENV_VENV_IN_PROJECT=1
 export NODE_ENV=production
 (trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/module-scan run & make -C vxsuite/apps/module-smartcards run & make -C vxsuite/apps/precinct-scanner run)


### PR DESCRIPTION
For development purposes, it's nice to fail fast with a clear error message.