### PR TITLE
fix: allow alphanumeric and dashes in machine ID

### DIFF
--- a/config/admin-functions/choose-vx-machine-id.sh
+++ b/config/admin-functions/choose-vx-machine-id.sh
@@ -6,12 +6,12 @@ set -euo pipefail
 
 while true; do
   read -p "${VX_MACHINE_TYPE} Machine ID (e.g. 0012): " MACHINE_ID
-  if [[ "${MACHINE_ID}" =~ ^[0-9]+$ ]]; then
+  if [[ "${MACHINE_ID}" =~ ^[-0-9A-Z]+$ ]]; then
     mkdir -p "${VX_CONFIG_ROOT}"
     sudo hostnamectl set-hostname "vx-${VX_MACHINE_TYPE}-${MACHINE_ID}"
     echo "${MACHINE_ID}" > "${VX_CONFIG_ROOT}/machine-id"
     break
   else
-    echo -e "\e[31mExpected Machine ID to be non-empty and only numbers, got: ${MACHINE_ID}\e[0m" >&2
+    echo -e "\e[31mExpected Machine ID to be non-empty and contain only numbers, uppercase letters, and dashes, got: ${MACHINE_ID}\e[0m" >&2
   fi
 done


### PR DESCRIPTION
Per [@adghayes](https://votingworks.slack.com/archives/CEL6D3GAD/p1628532274070400?thread_ts=1625587649.004000&cid=CEL6D3GAD):

> @adghayes: when I try to change it in tty2, I get a validation error saying that only digits are allowed
> @eventualbuddha: what should we allow?
> @adghayes: alphanumeric + dashes, I think
