### PR TITLE
Adds setup script for key generation, working towards #853

### DIFF
--- a/setup-signify.sh
+++ b/setup-signify.sh
@@ -4,10 +4,10 @@ set -euo pipefail
 sudo apt -y install signify-openbsd qrencode
 
 # clear out old keys
-rm -f key.pub key.sec
+rm -f /vx/config/key.pub /vx/config/key.sec
 
 # Generate the keypair
 signify-openbsd -G -n -p /vx/config/key.pub -s /vx/config/key.sec
 
 # Output the public key for enrollment into another device
-qrencode -t UTF8 -r key.pub -o -
+qrencode -t UTF8 -r /vx/config/key.pub -o -

--- a/setup-signify.sh
+++ b/setup-signify.sh
@@ -1,13 +1,21 @@
 #!/bin/bash
 set -euo pipefail 
 
-sudo apt -y install signify-openbsd qrencode
+if [ $# -eq 1 ]; then
+    wd=$1
 
-# clear out old keys
-rm -f /vx/config/key.pub /vx/config/key.sec
+    sudo apt -y install signify-openbsd qrencode
 
-# Generate the keypair
-signify-openbsd -G -n -p /vx/config/key.pub -s /vx/config/key.sec
+    # clear out old keys
+    rm -f $wd/key.pub $wd/key.sec
 
-# Output the public key for enrollment into another device
-qrencode -t UTF8 -r /vx/config/key.pub -o -
+    # Generate the keypair
+    signify-openbsd -G -n -p $wd/key.pub -s $wd/key.sec
+
+    # Output the public key for enrollment into another device
+    qrencode -t UTF8 -r $wd/key.pub -o -
+else 
+    echo "Usage: ./setup-signify [directory]"
+    exit;
+fi
+

--- a/setup-signify.sh
+++ b/setup-signify.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+set -euo pipefail 
+
+sudo apt -y install signify-openbsd qrencode
+
+# clear out old keys
+rm -f key.pub key.sec
+
+# Generate the keypair
+signify-openbsd -G -n -p /vx/config/key.pub -s /vx/config/key.sec
+
+# Output the public key for enrollment into another device
+qrencode -t UTF8 -r key.pub -o -

--- a/setup-signify.sh
+++ b/setup-signify.sh
@@ -1,21 +1,22 @@
 #!/bin/bash
 set -euo pipefail 
 
-if [ $# -eq 1 ]; then
-    wd=$1
-
-    sudo apt -y install signify-openbsd qrencode
-
-    # clear out old keys
-    rm -f $wd/key.pub $wd/key.sec
-
-    # Generate the keypair
-    signify-openbsd -G -n -p $wd/key.pub -s $wd/key.sec
-
-    # Output the public key for enrollment into another device
-    qrencode -t UTF8 -r $wd/key.pub -o -
-else 
+if [ $# -ne 1 ]; then
     echo "Usage: ./setup-signify [directory]"
-    exit;
+    exit 1
 fi
+
+public_path="${1}/key.pub"
+secret_path="${1}/key.sec"
+
+
+sudo apt -y install signify-openbsd qrencode
+
+# clear out old keys
+rm -f "${public_path}" "${secret_path}"
+
+# Generate the keypair
+signify-openbsd -G -n -p "${public_path}" -s "${secret_path}"
+# Output the public key for enrollment into another device
+qrencode -t UTF8 -r "${public_path}"  -o -
 


### PR DESCRIPTION
Installs signify-openbsd and qrencode, creates a keypair and outputs a QR code corresponding to the public key.