### PR TITLE
if totp clean fails, that's okay, just continue

### DIFF
--- a/setup-tpm2-totp.sh
+++ b/setup-tpm2-totp.sh
@@ -22,8 +22,8 @@ sudo apt -y install build-essential autoconf autoconf-archive automake m4 libtoo
 # reindex shared objects
 sudo ldconfig
 
-# clear out any preexisting TPM-bound TOTP
-sudo tpm2-totp clean
+# clear out any preexisting TPM-bound TOTP if there is one
+sudo tpm2-totp clean || true
 
 # initialize the TOTP code, which will display the QR code with the secret.
 sudo tpm2-totp --pcrs=0,7 init


### PR DESCRIPTION
on first TPM totp setup, `clean` errors out. That's not a problem, `clean` was there just to make this idempotent. So let's actually make it work on first run, too :)