### PR TITLE
temp workaround on build to make plustekctl work

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -54,6 +54,7 @@ build() {
     cd "${DIR}/vxsuite/apps/${APP}"
     pnpm install
     BUILD_ROOT="${BUILD_ROOT}/vxsuite" ./script/prod-build
+
     cp -rp \
       "${DIR}/run-scripts/run-${APP}.sh" \
       "${DIR}/run-scripts/run-kiosk-browser.sh" \
@@ -61,6 +62,11 @@ build() {
       "${DIR}/config" \
       "${DIR}/printing" \
       "${BUILD_ROOT}"
+
+    # temporary hack because the symlink works but somehow the copy doesn't for precinct-scanner
+    cd ${BUILD_ROOT}
+    rm -rf vxsuite # this is the built version
+    ln -s ../../vxsuite ./vxsuite
   ) && \
   echo "✅${APP} built!" || \
   (echo "✘ ${APP} build failed! check the logs above" >&2 && exit 1)

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -98,6 +98,10 @@ fi
 ./build.sh "${CHOICE}"
 sudo mv build/${CHOICE} /vx/code
 
+# temporary hack cause of precinct-scanner runtime issue
+sudo rm /vx/code/vxsuite # it's a symlink
+sudo cp -rp vxsuite /vx/code/
+
 # symlink the code and run-*.sh in /vx/services
 sudo ln -s /vx/code/vxsuite /vx/services/vxsuite
 sudo ln -s /vx/code/run-${CHOICE}.sh /vx/services/run-${CHOICE}.sh


### PR DESCRIPTION
this workaround makes things work in pre-locked-down mode, and in production mode.

Ignores the prod-optimized build and just uses the original `vxsuite` directory, symlinked for pre-lockdown, copied for locked down.