### PR TITLE
Setup basic application logging configuration

### DIFF
--- a/config/30-votingworks.conf
+++ b/config/30-votingworks.conf
@@ -1,0 +1,15 @@
+template(name="outfmt" type="list" option.jsonf="on") {
+         constant(value="{")
+         property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")
+         constant(value=",")
+         property(outname="host" name="hostname" format="jsonf")
+         constant(value=",")
+         property(outname="message" name="msg" position.from="3")
+         constant(value="\n")
+ }
+
+# reformat json messages into one json blob and send to vx-logs.log
+if $syslogtag == "votingworksapp:" and re_match($msg,'^ *\\{.*\\} *$') then /var/log/vx-logs.log;outfmt
+&stop # excludes the messages matched above from being matched by other rules
+# send all other non-json messages from votingworksapp to the main syslog
+if $syslogtag == "votingworksapp:" then -/var/log/syslog

--- a/config/admin-functions/copy-logs.sh
+++ b/config/admin-functions/copy-logs.sh
@@ -31,6 +31,7 @@ mkdir -p "$DIRECTORY"
 # copy logs
 cp -rp /var/log/syslog* "$DIRECTORY"
 cp -rp /var/log/auth.log* "$DIRECTORY"
+cp -rp /var/log/vx-logs.log* "$DIRECTORY"
 
 # unmount the USB stick to make sure it's all written to disk
 pumount "$DEVICES"

--- a/config/vx-bas.service
+++ b/config/vx-bas.service
@@ -8,7 +8,7 @@ Environment=VX_CONFIG_ROOT=/vx/config
 ExecStart=/bin/bash /vx/services/run-bas.sh
 StandardOutput=syslog
 StandardError=syslog
-SyslogIdentifier=bas
+SyslogIdentifier=votingworksapp
 
 [Install]
 WantedBy=multi-user.target

--- a/config/vx-bmd.service
+++ b/config/vx-bmd.service
@@ -8,7 +8,7 @@ Environment=VX_CONFIG_ROOT=/vx/config
 ExecStart=/bin/bash /vx/services/run-bmd.sh
 StandardOutput=syslog
 StandardError=syslog
-SyslogIdentifier=bmd
+SyslogIdentifier=votingworksapp
 
 [Install]
 WantedBy=multi-user.target

--- a/config/vx-bsd.service
+++ b/config/vx-bsd.service
@@ -9,7 +9,7 @@ Environment=MODULE_SCAN_WORKSPACE=/vx/data/module-scan
 ExecStart=/bin/bash /vx/services/run-bsd.sh
 StandardOutput=syslog
 StandardError=syslog
-SyslogIdentifier=bsd
+SyslogIdentifier=votingworksapp
 
 [Install]
 WantedBy=multi-user.target

--- a/config/vx-election-manager.service
+++ b/config/vx-election-manager.service
@@ -9,7 +9,7 @@ Environment=MODULE_SEMS_CONVERTER_WORKSPACE=/vx/data/module-sems-converter
 ExecStart=/bin/bash /vx/services/run-election-manager.sh
 StandardOutput=syslog
 StandardError=syslog
-SyslogIdentifier=election-manager
+SyslogIdentifier=votingworksapp
 
 [Install]
 WantedBy=multi-user.target

--- a/config/vx-precinct-scanner.service
+++ b/config/vx-precinct-scanner.service
@@ -9,7 +9,7 @@ Environment=MODULE_SCAN_WORKSPACE=/vx/data/module-scan
 ExecStart=/bin/bash /vx/services/run-precinct-scanner.sh
 StandardOutput=syslog
 StandardError=syslog
-SyslogIdentifier=precinct-scanner
+SyslogIdentifier=votingworksapp
 
 [Install]
 WantedBy=multi-user.target

--- a/run-scripts/run-bas.sh
+++ b/run-scripts/run-bas.sh
@@ -11,4 +11,4 @@ source ${CONFIG}/read-vx-machine-config.sh
 
 export PIPENV_VENV_IN_PROJECT=1
 export NODE_ENV=production
-(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/module-smartcards run & make -C vxsuite/apps/bas run)
+(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/module-smartcards run & make -C vxsuite/apps/bas run) | logger --tag votingworksapp

--- a/run-scripts/run-bmd.sh
+++ b/run-scripts/run-bmd.sh
@@ -11,4 +11,4 @@ source ${CONFIG}/read-vx-machine-config.sh
 
 export PIPENV_VENV_IN_PROJECT=1
 export NODE_ENV=production
-(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/module-smartcards run & make -C vxsuite/apps/bmd run)
+(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/module-smartcards run & make -C vxsuite/apps/bmd run) | logger --tag votingworksapp

--- a/run-scripts/run-bsd.sh
+++ b/run-scripts/run-bsd.sh
@@ -16,4 +16,4 @@ fi
 
 export PIPENV_VENV_IN_PROJECT=1
 export NODE_ENV=production
-(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/module-smartcards run & make -C vxsuite/apps/module-scan run & make -C vxsuite/apps/bsd run)
+(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/module-smartcards run & make -C vxsuite/apps/module-scan run & make -C vxsuite/apps/bsd run) | logger --tag votingworksapp

--- a/run-scripts/run-election-manager.sh
+++ b/run-scripts/run-election-manager.sh
@@ -11,4 +11,4 @@ source ${CONFIG}/read-vx-machine-config.sh
 
 export PIPENV_VENV_IN_PROJECT=1
 export NODE_ENV=production
-(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/module-smartcards run & make -C vxsuite/apps/module-converter-ms-sems run & make -C vxsuite/apps/election-manager run)
+(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/module-smartcards run & make -C vxsuite/apps/module-converter-ms-sems run & make -C vxsuite/apps/election-manager run) | logger --tag votingworksapp

--- a/run-scripts/run-kiosk-browser-forever-and-log.sh
+++ b/run-scripts/run-kiosk-browser-forever-and-log.sh
@@ -28,4 +28,4 @@ fi
 while true; do
     echo "starting kiosk-browser"
     ./run-kiosk-browser.sh "$URL"
-done 2>&1 | logger --tag kiosk-browser
+done 2>&1 | logger --tag votingworksapp

--- a/run-scripts/run-precinct-scanner.sh
+++ b/run-scripts/run-precinct-scanner.sh
@@ -16,4 +16,4 @@ fi
 
 export PIPENV_VENV_IN_PROJECT=1
 export NODE_ENV=production
-(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/module-scan run & make -C vxsuite/apps/module-smartcards run & make -C vxsuite/apps/precinct-scanner run)
+(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/module-scan run & make -C vxsuite/apps/module-smartcards run & make -C vxsuite/apps/precinct-scanner run) | logger --tag votingworksapp

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -88,6 +88,9 @@ sudo rm -rf /vx/services/* /vx/ui/* /vx/admin/*
 # Let vx-admin read logs
 sudo usermod -aG adm vx-admin
 
+# Set up log config
+sudo cp config/30-votingworks.conf /etc/rsyslog.d/30-votingworks.conf
+
 # Let some users mount/unmount usb disks
 if [ "${CHOICE}" != "bmd" ] && [ "${CHOICE}" != "bas" ] 
 then


### PR DESCRIPTION
Starts a custom rsyslog configuration file with initial setup to route application logs. This will route any logs that are JSON messages (i.e. enclosed in brackets) to the vx-logs.log file, and expand the json blob to include the hostname and the time the logging actually occurred, we can include other details if we want as well. Anything that comes from our applications that is NOT json will be sent to syslog like it is currently. I updated all of the service files AND the kiosk-browser syslog tags to "votingworksapp" so they will all hit this routing, this means this should work the same regardless of if the logs come from kiosk-browser or the apps themselves (or both!), but as we solidify a decision there I may update this. I also update the run-scripts to tag the applications output with the same syslog tag and send the logs to logger to make testing easier. The addition of vx-logs to the copy logs admin function is also just for debugging until we have a better export process.

Attached the output of vx-logs.log after running setup-machine machine on an election manager instance. I also check that syslog had the other logs from the application. 
[vx-logs.log](https://github.com/votingworks/vxsuite-complete-system/files/7414577/vx-logs.log) 

Note that the "time" field here is from my other PR, I will rename it to something clearer there (like timeLogInitiated or something)