### PR TITLE
feat(vcs) log machine boots shutdowns and restarts

### DIFF
--- a/config/30-votingworks.conf
+++ b/config/30-votingworks.conf
@@ -1,4 +1,4 @@
-template(name="outfmt" type="list" option.jsonf="on") {
+template(name="jsonfmt" type="list") {
          constant(value="{")
          property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")
          constant(value=",")
@@ -9,7 +9,59 @@ template(name="outfmt" type="list" option.jsonf="on") {
  }
 
 # reformat json messages into one json blob and send to vx-logs.log
-if $syslogtag == "votingworksapp:" and re_match($msg,'^ *\\{.*\\} *$') then /var/log/vx-logs.log;outfmt
+if $syslogtag == "votingworksapp:" and re_match($msg,'^ *\\{.*\\} *$') then /var/log/vx-logs.log;jsonfmt
 &stop # excludes the messages matched above from being matched by other rules
 # send all other non-json messages from votingworksapp to the main syslog
 if $syslogtag == "votingworksapp:" then -/var/log/syslog
+
+# Handle routing of system logs
+
+## Route logs for machine boot
+template(name="machineBootInit" type="list" option.jsonf="on") {
+         property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")
+         property(outname="host" name="hostname" format="jsonf")
+         constant(outname="source" value="system" format="jsonf")
+         constant(outname="eventId" value="machine-boot-init" format="jsonf")
+         constant(outname="eventType" value="system-action" format="jsonf")
+         constant(outname="user" value="system" format="jsonf")
+         constant(outname="disposition" value="na" format="jsonf")
+         constant(outname="message" value="Machine boot initiated" format="jsonf")
+ }
+template(name="machineBootSuccess" type="list" option.jsonf="on") {
+         property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")
+         property(outname="host" name="hostname" format="jsonf")
+         constant(outname="source" value="system" format="jsonf")
+         constant(outname="eventId" value="machine-boot-complete" format="jsonf")
+         constant(outname="eventType" value="system-status" format="jsonf")
+         constant(outname="user" value="system" format="jsonf")
+         constant(outname="disposition" value="success" format="jsonf")
+         property(outname="message" name="msg" format="jsonf")
+ }
+
+if $programname == "kernel" and $msg startswith "Command line: BOOT_IMAGE" then /var/log/vx-logs.log;machineBootInit
+if $syslogtag == "systemd[1]:" and $msg contains "Startup finished" then /var/log/vx-logs.log;machineBootSuccess
+
+## Route logs for machine shutdown
+template(name="machineShutdownInit" type="list" option.jsonf="on") {
+         property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")
+         property(outname="host" name="hostname" format="jsonf")
+         constant(outname="source" value="system" format="jsonf")
+         constant(outname="eventId" value="machine-shutdown-init" format="jsonf")
+         constant(outname="eventType" value="system-action" format="jsonf")
+         constant(outname="user" value="system" format="jsonf")
+         constant(outname="disposition" value="na" format="jsonf")
+         property(outname="message" name="msg" format="jsonf")
+ }
+template(name="machineShutdownSuccess" type="list" option.jsonf="on") {
+         property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")
+         property(outname="host" name="hostname" format="jsonf")
+         constant(outname="source" value="system" format="jsonf")
+         constant(outname="eventId" value="machine-shutdown-complete" format="jsonf")
+         constant(outname="eventType" value="system-status" format="jsonf")
+         constant(outname="user" value="system" format="jsonf")
+         constant(outname="disposition" value="success" format="jsonf")
+         property(outname="message" name="msg" format="jsonf")
+ }
+
+if $programname == "systemd-logind" and ($msg contains "System is rebooting" or $msg contains "System is powering down") then /var/log/vx-logs.log;machineShutdownInit
+if $syslogtag == "systemd[1]:" and $msg contains "Shutting down" then /var/log/vx-logs.log;machineShutdownSuccess

--- a/config/journald.conf
+++ b/config/journald.conf
@@ -1,0 +1,42 @@
+#  This file is part of systemd.
+#
+#  systemd is free software; you can redistribute it and/or modify it
+#  under the terms of the GNU Lesser General Public License as published by
+#  the Free Software Foundation; either version 2.1 of the License, or
+#  (at your option) any later version.
+#
+# Entries in this file show the compile time defaults.
+# You can change settings by editing this file.
+# Defaults can be restored by simply deleting this file.
+#
+# See journald.conf(5) for details.
+
+[Journal]
+#Storage=auto
+#Compress=yes
+#Seal=yes
+#SplitMode=uid
+#SyncIntervalSec=5m
+#RateLimitIntervalSec=0
+#RateLimitBurst=0
+#SystemMaxUse=
+#SystemKeepFree=
+#SystemMaxFileSize=
+#SystemMaxFiles=100
+#RuntimeMaxUse=
+#RuntimeKeepFree=
+#RuntimeMaxFileSize=
+#RuntimeMaxFiles=100
+#MaxRetentionSec=
+#MaxFileSec=1month
+ForwardToSyslog=no
+#ForwardToKMsg=no
+#ForwardToConsole=no
+#ForwardToWall=yes
+#TTYPath=/dev/console
+#MaxLevelStore=debug
+#MaxLevelSyslog=debug
+#MaxLevelKMsg=notice
+#MaxLevelConsole=info
+#MaxLevelWall=emerg
+#LineMax=48K

--- a/config/rsyslog.conf
+++ b/config/rsyslog.conf
@@ -1,0 +1,63 @@
+#  /etc/rsyslog.conf	Configuration file for rsyslog.
+#
+#			For more information see
+#			/usr/share/doc/rsyslog-doc/html/rsyslog_conf.html
+#
+#  Default logging rules can be found in /etc/rsyslog.d/50-default.conf
+
+
+#################
+#### MODULES ####
+#################
+
+#module(load="imuxsock") # provides support for local system logging
+module(load="imjournal" PersistStateInterval="100" StateFile="state")
+
+#module(load="mmjsonparse")
+
+#module(load="immark")  # provides --MARK-- message capability
+
+# provides UDP syslog reception
+#module(load="imudp")
+#input(type="imudp" port="514")
+
+# provides TCP syslog reception
+#module(load="imtcp")
+#input(type="imtcp" port="514")
+
+# provides kernel logging support and enable non-kernel klog messages
+module(load="imklog" permitnonkernelfacility="on")
+
+###########################
+#### GLOBAL DIRECTIVES ####
+###########################
+
+#
+# Use traditional timestamp format.
+# To enable high precision timestamps, comment out the following line.
+#
+$ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
+
+# Filter duplicated messages
+$RepeatedMsgReduction on
+
+#
+# Set the default permissions for all log files.
+#
+$FileOwner syslog
+$FileGroup adm
+$FileCreateMode 0640
+$DirCreateMode 0755
+$Umask 0022
+$PrivDropToUser syslog
+$PrivDropToGroup syslog
+
+#
+# Where to place spool and state files
+#
+$WorkDirectory /var/spool/rsyslog
+
+#
+# Include all config files in /etc/rsyslog.d/
+#
+$IncludeConfig /etc/rsyslog.d/*.conf

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -60,6 +60,11 @@ sudo apt install -y unclutter mingetty pmount brightnessctl
 # simple window manager and remove all contextual info
 sudo apt install -y openbox
 
+# update version of rsyslog
+sudo add-apt-repository -y ppa:adiscon/v8-devel
+sudo apt-get update
+sudo apt-get install -y rsyslog
+
 # turn off automatic updates
 sudo cp config/20auto-upgrades /etc/apt/apt.conf.d/
 
@@ -90,6 +95,8 @@ sudo usermod -aG adm vx-admin
 
 # Set up log config
 sudo cp config/30-votingworks.conf /etc/rsyslog.d/30-votingworks.conf
+sudo cp config/rsyslog.conf /etc/rsyslog.conf
+sudo cp config/journald.conf /etc/systemd/journald.conf
 
 # Let some users mount/unmount usb disks
 if [ "${CHOICE}" != "bmd" ] && [ "${CHOICE}" != "bas" ] 


### PR DESCRIPTION
Adds logs for machine boots, shutdowns, and restarts. Will update type types in vxsuite to reflect these changes. 

A few things I'm open to feedback on

- I opted to reuse 1 event id for both powering down and rebooting, but the message in the log tells you which it is thats happening so we could make these unique event ids if that is preferred
- I'm very unsure about how granular to make the "event types" and what the distinctions should be, its not really necessary at all except its a required field in the CDF (but we get to define our own types with documentation for them) we could just make them message and error, for example. The distinction I tried to make here between system-action and system-status is that action is when something was initiated (like the boot/shutdown) and the status is just an update message about the status of some process. But ... I don't feel strongly. 
- I had to update rsyslog in order to get an easier way to create json logs, but its possible to do it in the default version of rsyslog with this ubuntu build if we don't want to do that, just uglier. 

Example logs after shutting down, booting, and then restarting:
`
{"timeLogWritten":"2021-10-27T18:20:03.146528-07:00", "host":"ubuntu", "source": "system", "eventId": "machine-shutdown-init", "eventType": "system-action", "user": "system", "disposition": "na", "message":"System is powering down."}
{"timeLogWritten":"2021-10-27T18:20:04.367379-07:00", "host":"ubuntu", "source": "system", "eventId": "machine-shutdown-complete", "eventType": "system-status", "user": "system", "disposition": "success", "message":"Shutting down."}
{"timeLogWritten":"2021-10-27T18:20:17.306429-07:00", "host":"ubuntu", "source": "system", "eventId": "machine-boot-init", "eventType": "system-action", "user": "system", "disposition": "na", "message": "Machine boot initiated"}
{"timeLogWritten":"2021-10-27T18:20:18.860397-07:00", "host":"ubuntu", "source": "system", "eventId": "machine-boot-complete", "eventType": "system-status", "user": "system", "disposition": "success", "message":"Startup finished in 4.007s (kernel) + 1.691s (userspace) = 5.698s."}
{"timeLogWritten":"2021-10-27T18:20:37.937462-07:00", "host":"ubuntu", "source": "system", "eventId": "machine-shutdown-init", "eventType": "system-action", "user": "system", "disposition": "na", "message":"System is rebooting."}
{"timeLogWritten":"2021-10-27T18:20:39.119368-07:00", "host":"ubuntu", "source": "system", "eventId": "machine-shutdown-complete", "eventType": "system-status", "user": "system", "disposition": "success", "message":"Shutting down."}
{"timeLogWritten":"2021-10-27T18:20:45.253301-07:00", "host":"ubuntu", "source": "system", "eventId": "machine-boot-init", "eventType": "system-action", "user": "system", "disposition": "na", "message": "Machine boot initiated"}
{"timeLogWritten":"2021-10-27T18:20:46.770967-07:00", "host":"ubuntu", "source": "system", "eventId": "machine-boot-complete", "eventType": "system-status", "user": "system", "disposition": "success", "message":"Startup finished in 3.828s (kernel) + 1.662s (userspace) = 5.490s."}`