### PR TITLE
fix bug in log routing

### DIFF
--- a/config/30-votingworks.conf
+++ b/config/30-votingworks.conf
@@ -9,10 +9,10 @@ template(name="jsonfmt" type="list") {
  }
 
 # reformat json messages into one json blob and send to vx-logs.log
-if $syslogtag == "votingworksapp:" and re_match($msg,'^ *\\{.*\\} *$') then /var/log/vx-logs.log;jsonfmt
+if $programname == "votingworksapp" and re_match($msg,'^ *\\{.*\\} *$') then /var/log/vx-logs.log;jsonfmt
 &stop # excludes the messages matched above from being matched by other rules
 # send all other non-json messages from votingworksapp to the main syslog
-if $syslogtag == "votingworksapp:" then -/var/log/syslog
+if $programname == "votingworksapp" then -/var/log/syslog
 
 # Handle routing of system logs
 


### PR DESCRIPTION
I'm not really sure what changed here to cause this, but before when I was testing there was no process id for things coming from "votingworksapp" making the syslog tag comparison I was doing match, but now there is a process id so it doesn't match, regardless we should just check the programname anyway as that is safer and avoid this issue. 