### PR TITLE
feat(vcs) route logs for usb detection

### DIFF
--- a/config/30-votingworks.conf
+++ b/config/30-votingworks.conf
@@ -14,6 +14,19 @@ if $programname == "votingworksapp" and re_match($msg,'^ *\\{.*\\} *$') then /va
 # send all other non-json messages from votingworksapp to the main syslog
 if $programname == "votingworksapp" then -/var/log/syslog
 
+template(name="usbDeviceInformation" type="list" option.jsonf="on") {
+         property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")
+         property(outname="host" name="hostname" format="jsonf")
+         property(outname="message" name="msg" format="jsonf")
+         constant(outname="source" value="system" format="jsonf")
+         constant(outname="eventId" value="usb-device-change-detected" format="jsonf")
+         constant(outname="eventType" value="system-status" format="jsonf")
+         constant(outname="user" value="system" format="jsonf")
+         constant(outname="disposition" value="na" format="jsonf")
+ }
+
+if $programname == "kernel" and ($msg startsWith "usb") then /var/log/vx-logs.log;usbDeviceInformation
+
 # Handle routing of system logs
 
 ## Route logs for machine boot
@@ -65,3 +78,4 @@ template(name="machineShutdownSuccess" type="list" option.jsonf="on") {
 
 if $programname == "systemd-logind" and ($msg contains "System is rebooting" or $msg contains "System is powering down") then /var/log/vx-logs.log;machineShutdownInit
 if $syslogtag == "systemd[1]:" and $msg contains "Shutting down" then /var/log/vx-logs.log;machineShutdownSuccess
+

--- a/run.sh
+++ b/run.sh
@@ -47,7 +47,7 @@ if [[ " ${ALL_APPS[@]} " =~ " ${APP} " ]]; then
 
   export DISPLAY=:0
   cd "${DIR}/build/${APP}"
-  (trap 'kill 0' SIGINT SIGHUP; "./run-${APP}.sh" & ("./run-kiosk-browser.sh"; kill 0))
+  (trap 'kill 0' SIGINT SIGHUP; "./run-${APP}.sh" & ("./run-kiosk-browser.sh"; kill 0)) | logger --tag votingworksapp
 elif [[ "${APP}" = -h || "${APP}" = --help ]]; then
   usage
   exit 0


### PR DESCRIPTION
Adds logs for when usb devices connect/disconnect from the machine. 

Unforunately the logs related to this are multiple multi-line logs so its not clear to me that its a good idea to only select one of these logs to port into vx-logs as then we would be leaving behind potentially useful information, so instead I made this log event id more of a catchall to log all the different messages that come through when you connect a new usb device. This is a little messy to read in the json format, but ensures that we don't lose useful info (like the product name of the device, or the ID that the device is mounted to which is the only identifier in the log when something disconnects). 

Sample logs that also include the application logs: 
`{"timeLogWritten":"2021-11-03T16:38:09.384062-07:00","host":"ubuntu",timeLogInitiated":"1635982689382","source":"vx-admin","eventId":"usb-drive-status-update","eventType":"application-status","user":"system","message":"USB Drive status updated from undefined to absent","disposition":"na","newStatus":"absent"}
{"timeLogWritten":"2021-11-03T16:38:09.524581-07:00","host":"ubuntu",timeLogInitiated":"1635982689522","source":"vx-admin","eventId":"admin-card-inserted","eventType":"user-action","user":"unknown","message":"Admin smartcard inserted, the user will be prompted for passcode to complete authentication.","disposition":"na"}
{"timeLogWritten":"2021-11-03T16:38:11.456747-07:00","host":"ubuntu",timeLogInitiated":"1635982691455","source":"vx-admin","eventId":"admin-authentication-2fac","eventType":"user-action","user":"admin","message":"Admin user successfully authenticated with the correct passcode.","disposition":"success"}
{"timeLogWritten":"2021-11-03T16:38:11.468071-07:00","host":"ubuntu",timeLogInitiated":"1635982691467","source":"vx-admin","eventId":"user-session-activation","eventType":"user-action","user":"admin","message":"Authenticated admin session initiated.","disposition":"success"}
{"timeLogWritten":"2021-11-03T16:38:41.133344-07:00","host":"ubuntu",timeLogInitiated":"1635982721131","source":"vx-admin","eventId":"usb-drive-status-update","eventType":"application-status","user":"system","message":"USB Drive status updated from undefined to absent","disposition":"na","newStatus":"absent"}
{"timeLogWritten":"2021-11-03T16:38:41.199509-07:00","host":"ubuntu",timeLogInitiated":"1635982721198","source":"vx-admin","eventId":"usb-drive-status-update","eventType":"application-status","user":"system","message":"USB Drive status updated from undefined to absent","disposition":"na","newStatus":"absent"}
{"timeLogWritten":"2021-11-03T16:38:41.253812-07:00","host":"ubuntu",timeLogInitiated":"1635982721251","source":"vx-admin","eventId":"admin-card-inserted","eventType":"user-action","user":"unknown","message":"Admin smartcard inserted, the user will be prompted for passcode to complete authentication.","disposition":"na"}
{"timeLogWritten":"2021-11-03T16:38:43.490472-07:00","host":"ubuntu",timeLogInitiated":"1635982723489","source":"vx-admin","eventId":"admin-authentication-2fac","eventType":"user-action","user":"admin","message":"Admin user successfully authenticated with the correct passcode.","disposition":"success"}
{"timeLogWritten":"2021-11-03T16:38:43.498928-07:00","host":"ubuntu",timeLogInitiated":"1635982723498","source":"vx-admin","eventId":"user-session-activation","eventType":"user-action","user":"admin","message":"Authenticated admin session initiated.","disposition":"success"}
{"timeLogWritten":"2021-11-03T16:38:49.062582-07:00", "host":"ubuntu", "message":"usb 1-7: new high-speed USB device number 19 using ehci-pci", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2021-11-03T16:38:49.218256-07:00", "host":"ubuntu", "message":"usb 1-7: New USB device found, idVendor=abcd, idProduct=1234, bcdDevice= 1.00", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2021-11-03T16:38:49.218572-07:00", "host":"ubuntu", "message":"usb 1-7: New USB device strings: Mfr=1, Product=2, SerialNumber=3", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2021-11-03T16:38:49.218749-07:00", "host":"ubuntu", "message":"usb 1-7: Product: UDisk           ", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2021-11-03T16:38:49.218934-07:00", "host":"ubuntu", "message":"usb 1-7: Manufacturer: General ", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2021-11-03T16:38:49.219102-07:00", "host":"ubuntu", "message":"usb 1-7: SerialNumber: Љ", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2021-11-03T16:38:49.219271-07:00", "host":"ubuntu", "message":"usb-storage 1-7:1.0: USB Mass Storage device detected", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2021-11-03T16:38:50.626178-07:00","host":"ubuntu",timeLogInitiated":"1635982730625","source":"vx-admin","eventId":"usb-drive-status-update","eventType":"application-status","user":"system","message":"USB Drive status updated from absent to present","disposition":"na","previousStatus":"absent","newStatus":"present"}
{"timeLogWritten":"2021-11-03T16:38:50.629997-07:00","host":"ubuntu",timeLogInitiated":"1635982730628","source":"vx-admin","eventId":"usb-drive-mount-init","eventType":"application-action","user":"system","message":"The USB Drive is attempting to mount. This action is taken automatically by the application when a new USB drive is detected.","disposition":"na"}
{"timeLogWritten":"2021-11-03T16:38:51.013681-07:00","host":"ubuntu",timeLogInitiated":"1635982731012","source":"vx-admin","eventId":"usb-drive-mount-complete","eventType":"application-status","user":"system","message":"USB Drive successfully mounted","disposition":"success"}
{"timeLogWritten":"2021-11-03T16:38:51.125622-07:00","host":"ubuntu",timeLogInitiated":"1635982731124","source":"vx-admin","eventId":"usb-drive-status-update","eventType":"application-status","user":"system","message":"USB Drive status updated from present to mounted","disposition":"na","previousStatus":"present","newStatus":"mounted"}
{"timeLogWritten":"2021-11-03T16:38:55.340803-07:00","host":"ubuntu",timeLogInitiated":"1635982735340","source":"vx-admin","eventId":"usb-drive-eject-init","eventType":"user-action","user":"admin","message":"The current USB drive was requested to eject, application will now eject...","disposition":"na"}
{"timeLogWritten":"2021-11-03T16:39:05.428417-07:00","host":"ubuntu",timeLogInitiated":"1635982745427","source":"vx-admin","eventId":"usb-drive-eject-complete","eventType":"application-status","user":"admin","message":"USB Drive successfully ejected.","disposition":"success"}
{"timeLogWritten":"2021-11-03T16:39:05.527206-07:00","host":"ubuntu",timeLogInitiated":"1635982745526","source":"vx-admin","eventId":"usb-drive-status-update","eventType":"application-status","user":"system","message":"USB Drive status updated from ejecting to present","disposition":"na","previousStatus":"ejecting","newStatus":"present"}
{"timeLogWritten":"2021-11-03T16:39:09.874215-07:00", "host":"ubuntu", "message":"usb 1-7: USB disconnect, device number 19", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2021-11-03T16:39:09.942714-07:00","host":"ubuntu",timeLogInitiated":"1635982749942","source":"vx-admin","eventId":"usb-drive-status-update","eventType":"application-status","user":"system","message":"USB Drive status updated from present to absent","disposition":"na","previousStatus":"present","newStatus":"absent"}
{"timeLogWritten":"2021-11-03T16:39:16.390455-07:00", "host":"ubuntu", "message":"usb 2-2: USB disconnect, device number 12", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2021-11-03T16:39:16.390870-07:00", "host":"ubuntu", "message":"usb 2-2.1: USB disconnect, device number 13", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2021-11-03T16:39:20.646216-07:00", "host":"ubuntu", "message":"usb 2-2: new full-speed USB device number 14 using uhci_hcd", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2021-11-03T16:39:20.806147-07:00", "host":"ubuntu", "message":"usb 2-2: New USB device found, idVendor=203a, idProduct=fffe, bcdDevice= 1.01", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2021-11-03T16:39:20.806496-07:00", "host":"ubuntu", "message":"usb 2-2: New USB device strings: Mfr=1, Product=2, SerialNumber=3", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2021-11-03T16:39:20.806645-07:00", "host":"ubuntu", "message":"usb 2-2: Product: Virtual USB1.1 HUB", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2021-11-03T16:39:20.806783-07:00", "host":"ubuntu", "message":"usb 2-2: Manufacturer: Parallels", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2021-11-03T16:39:20.806916-07:00", "host":"ubuntu", "message":"usb 2-2: SerialNumber: PW3.0", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2021-11-03T16:39:21.134362-07:00", "host":"ubuntu", "message":"usb 2-2.1: new full-speed USB device number 15 using uhci_hcd", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2021-11-03T16:39:21.246367-07:00", "host":"ubuntu", "message":"usb 2-2.1: New USB device found, idVendor=076b, idProduct=3031, bcdDevice= 1.03", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2021-11-03T16:39:21.247631-07:00", "host":"ubuntu", "message":"usb 2-2.1: New USB device strings: Mfr=1, Product=2, SerialNumber=0", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2021-11-03T16:39:21.247902-07:00", "host":"ubuntu", "message":"usb 2-2.1: Product: OMNIKEY 3x21 Smart Card Reader", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2021-11-03T16:39:21.248049-07:00", "host":"ubuntu", "message":"usb 2-2.1: Manufacturer: HID Global", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2021-11-03T16:39:32.422212-07:00", "host":"ubuntu", "message":"usb 1-7: new high-speed USB device number 20 using ehci-pci", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2021-11-03T16:39:32.578309-07:00", "host":"ubuntu", "message":"usb 1-7: New USB device found, idVendor=abcd, idProduct=1234, bcdDevice= 1.00", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2021-11-03T16:39:32.578737-07:00", "host":"ubuntu", "message":"usb 1-7: New USB device strings: Mfr=1, Product=2, SerialNumber=3", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2021-11-03T16:39:32.579028-07:00", "host":"ubuntu", "message":"usb 1-7: Product: UDisk           ", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2021-11-03T16:39:32.579316-07:00", "host":"ubuntu", "message":"usb 1-7: Manufacturer: General ", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2021-11-03T16:39:32.579572-07:00", "host":"ubuntu", "message":"usb 1-7: SerialNumber: Љ", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2021-11-03T16:39:32.582380-07:00", "host":"ubuntu", "message":"usb-storage 1-7:1.0: USB Mass Storage device detected", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2021-11-03T16:39:33.944860-07:00","host":"ubuntu",timeLogInitiated":"1635982773944","source":"vx-admin","eventId":"usb-drive-status-update","eventType":"application-status","user":"system","message":"USB Drive status updated from absent to present","disposition":"na","previousStatus":"absent","newStatus":"present"}
{"timeLogWritten":"2021-11-03T16:39:33.951924-07:00","host":"ubuntu",timeLogInitiated":"1635982773951","source":"vx-admin","eventId":"usb-drive-mount-init","eventType":"application-action","user":"system","message":"The USB Drive is attempting to mount. This action is taken automatically by the application when a new USB drive is detected.","disposition":"na"}
{"timeLogWritten":"2021-11-03T16:39:34.236394-07:00","host":"ubuntu",timeLogInitiated":"1635982774231","source":"vx-admin","eventId":"usb-drive-mount-complete","eventType":"application-status","user":"system","message":"USB Drive successfully mounted","disposition":"success"}
{"timeLogWritten":"2021-11-03T16:39:34.327453-07:00","host":"ubuntu",timeLogInitiated":"1635982774327","source":"vx-admin","eventId":"usb-drive-status-update","eventType":"application-status","user":"system","message":"USB Drive status updated from present to mounted","disposition":"na","previousStatus":"present","newStatus":"mounted"}
{"timeLogWritten":"2021-11-03T16:39:38.270300-07:00", "host":"ubuntu", "message":"usb 1-7: USB disconnect, device number 20", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2021-11-03T16:39:38.384923-07:00","host":"ubuntu",timeLogInitiated":"1635982778379","source":"vx-admin","eventId":"usb-drive-status-update","eventType":"application-status","user":"system","message":"USB Drive status updated from mounted to absent","disposition":"na","previousStatus":"mounted","newStatus":"absent"}
`

If we do want only 1 system long when a new USB device is added I think we should go with this one: "usb 1-7: New USB device found, idVendor=abcd, idProduct=1234, bcdDevice= 1.00"


If we want to control specific devices we would set up udev to do that but udev does not seem to have useful logs to hook into here at this stage. 