### PR TITLE
feat(vcs) update run kiosk browser with permissions to read logs

### DIFF
--- a/run-scripts/run-kiosk-browser.sh
+++ b/run-scripts/run-kiosk-browser.sh
@@ -6,5 +6,11 @@ URL=${1:-http://localhost:3000}
 : "${VX_CONFIG_ROOT:="./config"}"
 
 
-kiosk-browser --add-file-perm o=http://localhost:3000,p=/media/**/*,rw --autoconfigure-print-config ./printing/printer-autoconfigure.json --url ${URL} --signify-secret-key ${VX_CONFIG_ROOT}/key.sec
+kiosk-browser \
+  --add-file-perm o=http://localhost:3000,p=/media/**/*,rw \
+  --add-file-perm o=http://localhost:3000,p=/var/log,ro \
+  --add-file-perm o=http://localhost:3000,p=/var/log/*,ro \
+  --autoconfigure-print-config ./printing/printer-autoconfigure.json \
+  --url ${URL} \
+  --signify-secret-key ${VX_CONFIG_ROOT}/key.sec
 


### PR DESCRIPTION
Updates run-kiosk-browser.sh with permissions to read the logs directory and the logs file. We need read access for the containing directory in order to see if the log file is present when exporting. I couldn't figure out how to get both of these in the same globbing pattern, I thought since` ** `matches any character including `/` that `/var/log**` should work but ... it didn't. 