### PR TITLE
build: rename config variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ This command will run all software services needed for election manager:
 This command will run all software services needed for ballot scanner:
 
 ```
-MODULE_SCAN_WORKSPACE=/tmp ./run.sh bsd
+SCAN_WORKSPACE=/tmp ./run.sh bsd
 ```
 
 You may replace `/tmp` with any persistent path you like.
@@ -58,7 +58,7 @@ follow the install instructions. Once you've done that, this command will run
 all software services needed for precinct scanner:
 
 ```
-MODULE_SCAN_WORKSPACE=/tmp ./run.sh precinct-scanner
+SCAN_WORKSPACE=/tmp ./run.sh precinct-scanner
 ```
 
 You may replace `/tmp` with any persistent path you like.

--- a/config/vx-bsd.service
+++ b/config/vx-bsd.service
@@ -5,7 +5,7 @@ Description=VotingWorks Ballot Scanner
 Type=simple
 User=vx-services
 Environment=VX_CONFIG_ROOT=/vx/config
-Environment=MODULE_SCAN_WORKSPACE=/vx/data/module-scan
+Environment=SCAN_WORKSPACE=/vx/data/module-scan
 ExecStart=/bin/bash /vx/services/run-bsd.sh
 StandardOutput=syslog
 StandardError=syslog

--- a/config/vx-precinct-scanner.service
+++ b/config/vx-precinct-scanner.service
@@ -5,7 +5,7 @@ Description=VotingWorks Precinct Scanner
 Type=simple
 User=vx-services
 Environment=VX_CONFIG_ROOT=/vx/config
-Environment=MODULE_SCAN_WORKSPACE=/vx/data/module-scan
+Environment=SCAN_WORKSPACE=/vx/data/module-scan
 ExecStart=/bin/bash /vx/services/run-precinct-scanner.sh
 StandardOutput=syslog
 StandardError=syslog

--- a/run-scripts/run-bsd.sh
+++ b/run-scripts/run-bsd.sh
@@ -9,8 +9,8 @@ cd "$(dirname "$0")"
 CONFIG=${VX_CONFIG_ROOT:-./config}
 source ${CONFIG}/read-vx-machine-config.sh
 
-if [ -z "${MODULE_SCAN_WORKSPACE:-}" ]; then
-  echo "error: please set MODULE_SCAN_WORKSPACE and try again" >&2
+if [ -z "${SCAN_WORKSPACE:-}" ]; then
+  echo "error: please set SCAN_WORKSPACE and try again" >&2
   exit 1
 fi
 

--- a/run-scripts/run-precinct-scanner.sh
+++ b/run-scripts/run-precinct-scanner.sh
@@ -9,8 +9,8 @@ cd "$(dirname "$0")"
 CONFIG=${VX_CONFIG_ROOT:-./config}
 source ${CONFIG}/read-vx-machine-config.sh
 
-if [ -z "${MODULE_SCAN_WORKSPACE:-}" ]; then
-  echo "error: please set MODULE_SCAN_WORKSPACE and try again" >&2
+if [ -z "${SCAN_WORKSPACE:-}" ]; then
+  echo "error: please set SCAN_WORKSPACE and try again" >&2
   exit 1
 fi
 


### PR DESCRIPTION
Renames `MODULE_SCAN_WORKSPACE` to `SCAN_WORKSPACE`. Follows #119 and votingworks/vxsuite#1226.