### PR TITLE
fix(vcs) fix bug with rsyslog port of application logs

### DIFF
--- a/config/30-votingworks.conf
+++ b/config/30-votingworks.conf
@@ -4,7 +4,7 @@ template(name="jsonfmt" type="list") {
          constant(value=",")
          property(outname="host" name="hostname" format="jsonf")
          constant(value=",")
-         property(outname="message" name="msg" position.from="3")
+         property(outname="message" name="msg" position.from="2")
          constant(value="\n")
  }
 


### PR DESCRIPTION
Fixes bug in the rsyslog configuration that translates the incoming application logs to vx-log.log. Noticed we were cutting over the proceeding " to the first key in the json, making the logs unparsable. 