### PR TITLE
fix(build): Handle build errors correctly

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -63,7 +63,6 @@ build() {
     cd "${DIR}/vxsuite/frontends/${APP}"
     pnpm install
     BUILD_ROOT="${BUILD_ROOT}/vxsuite" ./script/prod-build
-    echo $?
 
     cp -rp \
       "${DIR}/run-scripts/run-${APP}.sh" \

--- a/build.sh
+++ b/build.sh
@@ -63,6 +63,7 @@ build() {
     cd "${DIR}/vxsuite/frontends/${APP}"
     pnpm install
     BUILD_ROOT="${BUILD_ROOT}/vxsuite" ./script/prod-build
+    echo $?
 
     cp -rp \
       "${DIR}/run-scripts/run-${APP}.sh" \
@@ -77,9 +78,7 @@ build() {
     rm -rf vxsuite # this is the built version
     ln -s ../../vxsuite ./vxsuite
   )
-  status=$?
-  echo $status
-  if [[ $status = 0 ]]; then
+  if [[ $? = 0 ]]; then
     echo -e "\e[32m✅${APP} built\e[0m"
   else
     echo -e "\e[31m✘ ${APP} build failed! check the logs above\e[0m" >&2

--- a/build.sh
+++ b/build.sh
@@ -48,7 +48,11 @@ build() {
   echo "🔨Building ${APP}"
   export BUILD_ROOT="${DIR}/build/${APP}"
   rm -rf "${BUILD_ROOT}"
+  # In order to get the subshell exit code without exiting the whole script, we
+  # need to temporarily set +e
+  set +e
   (
+    set -euo pipefail
     for service in "${ALL_SERVICES[@]}"; do
       make -C "${DIR}/vxsuite/services/${service}" install
     done
@@ -72,9 +76,16 @@ build() {
     cd ${BUILD_ROOT}
     rm -rf vxsuite # this is the built version
     ln -s ../../vxsuite ./vxsuite
-  ) && \
-  echo "✅${APP} built!" || \
-  (echo "✘ ${APP} build failed! check the logs above" >&2 && exit 1)
+  )
+  status=$?
+  echo $status
+  if [[ $status = 0 ]]; then
+    echo -e "\e[32m✅${APP} built\e[0m"
+  else
+    echo -e "\e[31m✘ ${APP} build failed! check the logs above\e[0m" >&2
+    exit 1
+  fi
+  set -e
 }
 
 APPS=()


### PR DESCRIPTION
Due to some quirks of bash's `set -e` command and how it interacts with subshells, errors in the `build.sh` script were not getting handled correctly. The script would continue executing after a build error and print a success message.

More here: https://unix.stackexchange.com/questions/65532/why-does-set-e-not-work-inside-subshells-with-parenthesis-followed-by-an-or