### PR TITLE
fix(setup-machine): Add sudo to timedatectl command

### DIFF
--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -273,7 +273,7 @@ sudo cp config/grub /etc/default/grub
 sudo update-grub
 
 # turn off network
-timedatectl set-ntp no
+sudo timedatectl set-ntp no
 
 if [[  $DISTRO == "Ubuntu" ]]; then
 	sudo nmcli networking off


### PR DESCRIPTION
That way we don't get stuck waiting for a password on this step when running in dev.