### PR TITLE
feat: Run basic configuration on first boot

### DIFF
--- a/config/admin-functions/basic-configuration.sh
+++ b/config/admin-functions/basic-configuration.sh
@@ -37,6 +37,10 @@ while true; do
     [[ "${CONFIRM}" = "y" ]] && break
 done
 
+if [[ -f "${VX_CONFIG_ROOT}/RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT" ]]; then
+    rm -f "${VX_CONFIG_ROOT}/RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT"
+fi
+
 echo
 echo -e "\e[1mBasic Configuration Complete\e[0m"
 read -p "You must reboot for these changes to take effect. Reboot now? (y/n) " CONFIRM

--- a/config/admin-functions/show-vx-suite-admin-menu.sh
+++ b/config/admin-functions/show-vx-suite-admin-menu.sh
@@ -5,6 +5,11 @@ set -euo pipefail
 : "${VX_FUNCTIONS_ROOT:="$(dirname "$0")"}"
 : "${VX_CONFIG_ROOT:="/vx/config"}"
 
+if [[ $(tty) = /dev/tty1 ]] && [[ -f "${VX_CONFIG_ROOT}/RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT" ]]; then
+  "${VX_FUNCTIONS_ROOT}/basic-configuration.sh"
+  exit 0
+fi
+
 prompt-to-restart() {
   read -s -e -n 1 -p "Success! You must reboot for this change to take effect. Reboot now? (y/n) "
   if [[ ${REPLY} = "" || ${REPLY} = Y || ${REPLY} = y ]]; then
@@ -42,6 +47,9 @@ while true; do
   echo -e "\e[1mBasic Configuration\e[0m"
   echo "${#CHOICES[@]}. Run Basic Configuration Wizard"
   CHOICES+=('basic-configuration')
+
+  echo "${#CHOICES[@]}. Run Basic Configuration Wizard On Next Boot"
+  CHOICES+=('basic-configuration-on-next-boot')
 
   echo
   echo -e "\e[1mAdvanced\e[0m"
@@ -95,6 +103,10 @@ while true; do
 
     basic-configuration)
       "${VX_FUNCTIONS_ROOT}/basic-configuration.sh"
+    ;;
+
+    basic-configuration-on-next-boot)
+      touch "${VX_CONFIG_ROOT}/RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT"
     ;;
 
     set-machine-id)

--- a/config/admin_bash_profile
+++ b/config/admin_bash_profile
@@ -1,6 +1,4 @@
-if [[ $(tty) = /dev/tty2 ]]; then
-    while true; do
-   	bash /vx/admin/admin-functions/show-vx-suite-admin-menu.sh
-    done
-fi
+while true; do
+    bash /vx/admin/admin-functions/show-vx-suite-admin-menu.sh
+done
 

--- a/config/autologin.sh
+++ b/config/autologin.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+# This script is designed to be run in override.conf file for the service getty@tty1.
+# It conditionally selects which user to autologin based on whether or not the
+# machine needs configuration.
+if [[ -f /vx/config/RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT ]]; then
+    USER=vx-admin
+else
+    USER=vx-ui
+fi
+# For the getty service, you can't have any nested processes, thus we use exec to
+# make mingetty take over the process of this script.
+exec /sbin/mingetty --autologin $USER --noclear $1

--- a/config/cmdline
+++ b/config/cmdline
@@ -1,1 +1,1 @@
-BOOT_IMAGE=/vmlinuz-5.10.0-11-amd64 root=/dev/mapper/vroot ro quiet splash vt.handoff=7 fsck.mode=skip verity.hashdev=/dev/mapper/Vx--vg-hashes verity.rootdev=/dev/mapper/Vx--vg-root verity.hash=
+BOOT_IMAGE=/vmlinuz-5.10.0-11-amd64 root=/dev/mapper/vroot ro quiet vt.handoff=7 fsck.mode=skip verity.hashdev=/dev/mapper/Vx--vg-hashes verity.rootdev=/dev/mapper/Vx--vg-root verity.hash=

--- a/config/grub
+++ b/config/grub
@@ -9,7 +9,7 @@ GRUB_TIMEOUT=0
 GRUB_HIDDEN_TIMEOUT=0
 GRUB_HIDDEN_TIMEOUT_QUIET=true
 GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
-GRUB_CMDLINE_LINUX_DEFAULT="quiet splash"
+GRUB_CMDLINE_LINUX_DEFAULT="quiet"
 GRUB_CMDLINE_LINUX=""
 
 # Uncomment to enable BadRAM filtering, modify to suit your needs

--- a/config/override.conf
+++ b/config/override.conf
@@ -1,3 +1,7 @@
 [Service]
+# The specifier %I is the service instance name, in this case tty1
+# See https://www.freedesktop.org/software/systemd/man/systemd.unit.html#Specifiers
+# If you ever need to debug autologin, switch to tty2, log in at the prompt, and
+# then run systemctl status getty@tty1.service to find an error message.
 ExecStart=
-ExecStart=-/sbin/mingetty --autologin vx-ui --noclear %I
+ExecStart=-/vx/code/config/autologin.sh %I


### PR DESCRIPTION
Task: https://github.com/votingworks/vxsuite/issues/1448

- In setup-machine.sh, set a file flag RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT
- Configure an autologin script that checks for this flag. If the flag is present, it logs in vx-admin. Otherwise, it logs in vx-ui like normal
- When vx-admin is logged in, always run the admin menu script (regardless of which tty we're in, since in this flow it will be tty1 instead of the usual tty2)
- When showing the admin menu, if we see the file flag is set, just run the basic configuration wizard
- At the end of the wizard, remove the file flag
- Also adds an option to the menu to remove the file flag at any time