### PR TITLE
fix git output from showing up in terminal

### DIFF
--- a/vxdev/update-code.sh
+++ b/vxdev/update-code.sh
@@ -5,7 +5,7 @@
 APP_TYPE=$(sudo cat "$VX_CONFIG_ROOT/machine-type")
 
 cd /vx/code/vxsuite-complete-system
-git checkout main > /dev/null
+git checkout main > /dev/null 2>&1
 git pull > /dev/null
 git fetch --tags > /dev/null
 sudo git clean -xfd > /dev/null

--- a/vxdev/update-vxdev.sh
+++ b/vxdev/update-vxdev.sh
@@ -36,8 +36,8 @@ CHOICE=${CHOICES[$CHOICE_INDEX]}
 cd /vx/code/vxsuite-complete-system
 mkdir -p /vx/scripts
 
-git checkout main
-git pull
+git checkout main > /dev/null 2>&1
+git pull > /dev/null
 sudo cp vxdev/update-code.sh /vx/scripts/.
 sudo cp vxdev/update-vxdev.sh /vx/scripts/.
 sudo cp vxdev/update-code.desktop /usr/share/applications/.


### PR DESCRIPTION
removes some extraneous git command output from showing up when running the update and config programs in vxdev 

I also noticed I was sometimes getting weird permission errors when jumping back and forth between the latest code and the last stable release. Adding sudo fixed them but I admittedly don't really understand why there were issues and only on creating one specific file when there are multiple new files that have been added to vxsuite. But adding sudo felt safe. 