### PR TITLE
Don't show lock screen in vxdev

### DIFF
--- a/vxdev/update-vxdev.sh
+++ b/vxdev/update-vxdev.sh
@@ -47,6 +47,8 @@ sudo cp vxdev/updatecode.png /home/vx/.icons
 sudo cp vxdev/configurevxdev.png /home/vx/.icons
 sudo cp vxdev/runprogram.png /home/vx/.icons
 
+gsettings set org.gnome.desktop.lockdown disable-lock-screen 'true'
+
 FAVORITE_ICONS=''
 
 if [[ $CHOICE == 'VxMark' ]]; then


### PR DESCRIPTION
The image will also need to be configured to automatically log the vx user in on boot