### PR TITLE
VxDev improve updating flow and allow toggling of WIA feature flag

### DIFF
--- a/vxdev/default-env
+++ b/vxdev/default-env
@@ -1,0 +1,3 @@
+REACT_APP_VX_DEV=true
+# Uncomment the following line, then run 'Update Code',  to enable write in adjudication in VxDev
+# REACT_APP_VX_ENABLE_WRITE_IN_ADJUDICATION=true

--- a/vxdev/setup-vxdev-base-machine.sh
+++ b/vxdev/setup-vxdev-base-machine.sh
@@ -165,21 +165,6 @@ sudo bash setup-scripts/setup-signify.sh
 sudo timedatectl set-ntp no
 
 # Install app to configure VxDev
-sudo mkdir -p /vx/scripts
-sudo cp vxdev/update-vxdev.sh /vx/scripts/.
-sudo cp vxdev/update-vxdev.desktop /usr/share/applications/.
-gsettings set org.gnome.shell favorite-apps "['update-vxdev.desktop','firefox-esr.desktop', 'org.gnome.Nautilus.desktop']"
-
-sudo mkdir -p /home/vx/.icons
-sudo cp vxdev/updatecode.png /home/vx/.icons
-sudo cp vxdev/configurevxdev.png /home/vx/.icons
-sudo cp vxdev/runprogram.png /home/vx/.icons
-sudo cp vxdev/votingworks-desktop.png /vx/.
-gsettings set org.gnome.desktop.background picture-uri file:///vx/votingworks-desktop.png
-
-sudo cp vxdev/update-code.sh /vx/scripts/.
-sudo cp vxdev/update-vxdev.sh /vx/scripts/.
-sudo cp vxdev/update-code.desktop /usr/share/applications/.
-sudo cp vxdev/update-vxdev.desktop /usr/share/applications/.
+bash vxdev/vxdev-configuration.sh
 
 echo "Done with initial VxDev setup! You may now run the "Update and Configure VxDev" program."

--- a/vxdev/update-code.sh
+++ b/vxdev/update-code.sh
@@ -53,15 +53,19 @@ fi
 make build-kiosk-browser
 echo $APP_TYPE
 if [[ $APP_TYPE == 'VxCentralScan' ]] || [[ $APP_TYPE == 'VxAdminCentralScan' ]]; then
+	sudo cp /vx/config/.env.local vxsuite/frontends/bsd/.env.local
 	./build.sh bsd
 fi
 if [[ $APP_TYPE == 'VxAdmin' ]] || [[ $APP_TYPE == 'VxAdminCentralScan' ]]; then
+	sudo cp /vx/config/.env.local vxsuite/frontends/election-manager/.env.local
 	./build.sh election-manager
 fi
 if [[ $APP_TYPE == 'VxMark' ]]; then
+	sudo cp /vx/config/.env.local vxsuite/frontends/bmd/.env.local
 	./build.sh bmd
 fi
 if [[ $APP_TYPE == 'VxScan' ]]; then
+	sudo cp /vx/config/.env.local vxsuite/frontends/precinct-scanner/.env.local
 	./build.sh precinct-scanner
 fi
 

--- a/vxdev/update-vxdev.sh
+++ b/vxdev/update-vxdev.sh
@@ -34,23 +34,15 @@ CHOICE=${CHOICES[$CHOICE_INDEX]}
 
 
 cd /vx/code/vxsuite-complete-system
-mkdir -p /vx/scripts
 
+# Fetch the latest code
 git checkout main > /dev/null 2>&1
 git pull > /dev/null
-sudo cp vxdev/update-code.sh /vx/scripts/.
-sudo cp vxdev/update-vxdev.sh /vx/scripts/.
-sudo cp vxdev/update-code.desktop /usr/share/applications/.
-sudo cp vxdev/update-vxdev.desktop /usr/share/applications/.
 
-sudo cp vxdev/updatecode.png /home/vx/.icons
-sudo cp vxdev/configurevxdev.png /home/vx/.icons
-sudo cp vxdev/runprogram.png /home/vx/.icons
+# Update the configuration script and run it to fetch and apply any new updates to VxDev
+sudo cp vxdev/vxdev-configuration.sh /vx/scripts/.
+bash /vx/scripts/vxdev-configuration.sh
 
-gsettings set org.gnome.desktop.lockdown disable-lock-screen 'true'
-
-# Lock the kernel to a specific version, upgrades require testing and upgrading wifi drivers
-sudo cp vxdev/kernel /etc/apt/preferences/.
 
 FAVORITE_ICONS=''
 

--- a/vxdev/vxdev-configuration.sh
+++ b/vxdev/vxdev-configuration.sh
@@ -27,3 +27,5 @@ gsettings set org.gnome.desktop.lockdown disable-lock-screen 'true'
 
 # Lock the kernel to a specific version, upgrades require testing and upgrading wifi drivers
 sudo cp vxdev/kernel /etc/apt/preferences.d/.
+
+sudo cp vxdev/default-env /vx/config/.env.local

--- a/vxdev/vxdev-configuration.sh
+++ b/vxdev/vxdev-configuration.sh
@@ -1,0 +1,29 @@
+# Sets up the main configuration for VxDev. This file is automatically updated and re-run
+# when the VxDev "Update and Configure VxDev" program is run. Any updates to make to live VxDev
+# systems should be added to this file. This script should be able to be rerun multiple times safely.
+
+# Install app to configure VxDev
+sudo mkdir -p /vx/scripts
+sudo mkdir -p /home/vx/.icons
+
+# Copy icons and assets into the appropriate locations
+sudo cp vxdev/updatecode.png /home/vx/.icons
+sudo cp vxdev/configurevxdev.png /home/vx/.icons
+sudo cp vxdev/runprogram.png /home/vx/.icons
+sudo cp vxdev/votingworks-desktop.png /vx/.
+
+# Copy scripts and desktop files into the appropriate places
+sudo cp vxdev/update-code.sh /vx/scripts/.
+sudo cp vxdev/update-vxdev.sh /vx/scripts/.
+sudo cp vxdev/update-code.desktop /usr/share/applications/.
+sudo cp vxdev/update-vxdev.desktop /usr/share/applications/.
+
+# Set desktop background
+gsettings set org.gnome.desktop.background picture-uri file:///vx/votingworks-desktop.png
+# Set favorite apps
+gsettings set org.gnome.shell favorite-apps "['update-vxdev.desktop','firefox-esr.desktop', 'org.gnome.Nautilus.desktop']"
+# Disable lock screen
+gsettings set org.gnome.desktop.lockdown disable-lock-screen 'true'
+
+# Lock the kernel to a specific version, upgrades require testing and upgrading wifi drivers
+sudo cp vxdev/kernel /etc/apt/preferences.d/.


### PR DESCRIPTION
This PR does two things, one makes the flow to update VxDev a little easier. Before you had to run the "update VxDev" program twice in order to get updates as it first had it itself, and then you need to run the script again to run any changes in them. Plus I was putting key setup commands in both the "first time setup" script and this update program to make sure machines got new updates. This factors out into one shared script that both of the above scripts run to centralize the code, and to make it so the update program can update the script before running it, meaning changes will be applied from running the update program once. 

This also adds functionality to copy a default env file into /vx/config and into the shared frontends. This means that users of VxDev can edit the file located at /vx/config before running the Update Code program to toggle flags on/off. 