### PR TITLE
Prepare mount points for USB drives in production

### DIFF
--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -164,6 +164,18 @@ then
 fi
 sudo usermod -aG plugdev vx-admin
 
+# set up mount points ahead of time because read-only later
+sudo mkdir /media/usb-drive-sda1
+sudo mkdir /media/usb-drive-sdb1
+sudo mkdir /media/usb-drive-sdc1
+sudo mkdir /media/usb-drive-sdd1
+sudo mkdir /media/usb-drive-sde1
+sudo mkdir /media/usb-drive-sdf1
+sudo mkdir /media/usb-drive-sdg1
+sudo mkdir /media/usb-drive-sdh1
+
+sudo chown -R vx-ui:vx-group /media/usb-drive*
+
 # let vx-ui manage printers
 sudo usermod -aG lpadmin vx-ui
 


### PR DESCRIPTION
Because `/media` will be read-only.

In case we later wonder why this is our approach:
- no we can't symlink `/media` anywhere else without causing weirdness
- no we can't make `/media` a separate partition
- no we can't have `pmount` mount to a different location

So if we wanted to do this differently, we'd have to use `mount` instead of `pmount` to go to a different mount point maybe in `/var`. Using `mount` directly is riskier, so we'd probably want to wrap `mount` in a shell script and give `vx-ui` sudo access to that script only... all in all a lot of work compared to just preparing the mount points ahead of time.