### PR TITLE
Switching from signify keys to tpm-based keys

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,3 +129,13 @@ the combined repositories.
 We use git submodules here for the components, for the express purpose
 that we never want to update one of the components without explicitly
 checking that all the modules work well together.
+
+## Acknowledgments
+
+Thanks to Trammell Hudson (@osresearch) for help working out TPM- and dm-verity
+related stuff, and more generally for cutting the path for more secure Linux
+systems via the osresearch/safeboot project. 
+
+Thanks to Matthew Garrett (@mjg59)
+for providing overall thoughts about our security architecture, as well as
+helping to work out Secure Boot policies.

--- a/config/admin-functions/generate-key.sh
+++ b/config/admin-functions/generate-key.sh
@@ -4,10 +4,29 @@ set -euo pipefail
 
 : "${VX_CONFIG_ROOT:="/vx/config"}"
 
+
+set -euo pipefail 
+tpm2_startauthsession -S session.ctx
+tpm2_policypcr -S session.ctx -l "sha256:0,2,4,5,7" --policy pcr.policy
+tpm2_createprimary -C o -c primary.ctx
+
+# Save the primary context for reuse after reboot
+# First make sure nothing is in the handle we want to save our primary context
+# to
+tpm2_evictcontrol -Q -c 0x81000000 || true 2>&1 /dev/null
+tpm2_evictcontrol -c primary.ctx 0x81000000
+
+# Create a policy
+tpm2_create -L pcr.policy -u key.pub -C primary.ctx -G ecc -c key.ctx
+
+# Save the keys
+tpm2_evictcontrol -Q -c 0x81000001 || true 2>&1 /dev/null
+tpm2_evictcontrol -c key.ctx 0x81000001
+
+
 rm -f "${VX_CONFIG_ROOT}/key.pub" "${VX_CONFIG_ROOT}/key.sec"
-signify-openbsd -G -n -p "${VX_CONFIG_ROOT}/key.pub" -s "${VX_CONFIG_ROOT}/key.sec"
+tpm2_readpublic -c key.ctx -f PEM -o "${VX_CONFIG_ROOT}/key.pub"
+
 # Make the signing key readable by vx-group
 # We may want to further limit this in the future
-chgrp vx-group "${VX_CONFIG_ROOT}/key.sec"
-chmod g+r "${VX_CONFIG_ROOT}/key.sec"
 cat "${VX_CONFIG_ROOT}/key.pub" | qrencode -t ANSI -o -

--- a/config/admin-functions/generate-key.sh
+++ b/config/admin-functions/generate-key.sh
@@ -27,6 +27,4 @@ tpm2_evictcontrol -c key.ctx 0x81000001
 rm -f "${VX_CONFIG_ROOT}/key.pub" "${VX_CONFIG_ROOT}/key.sec"
 tpm2_readpublic -c key.ctx -f PEM -o "${VX_CONFIG_ROOT}/key.pub"
 
-# Make the signing key readable by vx-group
-# We may want to further limit this in the future
 cat "${VX_CONFIG_ROOT}/key.pub" | qrencode -t ANSI -o -

--- a/config/admin-functions/generate-key.sh
+++ b/config/admin-functions/generate-key.sh
@@ -7,7 +7,7 @@ set -euo pipefail
 
 set -euo pipefail 
 tpm2_startauthsession -S session.ctx
-tpm2_policypcr -S session.ctx -l "sha256:0,2,4,5,7" --policy pcr.policy
+tpm2_policypcr -S session.ctx -l "sha256:0,7" --policy pcr.policy
 tpm2_createprimary -C o -c primary.ctx
 
 # Save the primary context for reuse after reboot

--- a/config/admin-functions/show-vx-suite-admin-menu.sh
+++ b/config/admin-functions/show-vx-suite-admin-menu.sh
@@ -139,7 +139,7 @@ while true; do
     ;;
 
     generate-key)
-      "${VX_FUNCTIONS_ROOT}/generate-key.sh"
+      sudo "${VX_FUNCTIONS_ROOT}/generate-key.sh"
       read -s -n 1
     ;;
 

--- a/config/admin-functions/sign.sh
+++ b/config/admin-functions/sign.sh
@@ -6,7 +6,7 @@ tpm2 startauthsession -Q -S session.ctx --policy-session
 tpm2_policypcr -Q -S session.ctx -l "sha256:0,2,4,5,7" --policy pcr.policy
 
 # This expects the script to be run with the data to be signed passed in via 
-# a here-string, e.g. sudo ./sign.sh <<< $(cat data.blob).
+# a here-string, e.g. sudo ./sign.sh <<< "a string"
 # It "returns" the signature on stdout by catting a temporary file. 
 tpm2 sign -Q -p session:session.ctx -c 0x81000001 -f plain -o /tmp/sig 
 

--- a/config/admin-functions/sign.sh
+++ b/config/admin-functions/sign.sh
@@ -3,7 +3,7 @@
 set -euo pipefail
 
 tpm2 startauthsession -Q -S session.ctx --policy-session
-tpm2_policypcr -Q -S session.ctx -l "sha256:0,2,4,5,7" --policy pcr.policy
+tpm2_policypcr -Q -S session.ctx -l "sha256:0,7" --policy pcr.policy
 
 # This expects the script to be run with the data to be signed passed in via 
 # a here-string, e.g. sudo ./sign.sh <<< "a string"

--- a/config/admin-functions/sign.sh
+++ b/config/admin-functions/sign.sh
@@ -8,7 +8,8 @@ tpm2_policypcr -Q -S session.ctx -l "sha256:0,7" --policy pcr.policy
 # This expects the script to be run with the data to be signed passed in via 
 # a here-string, e.g. sudo ./sign.sh <<< "a string"
 # It "returns" the signature on stdout by catting a temporary file. 
-tpm2 sign -Q -p session:session.ctx -c 0x81000001 -f plain -o /tmp/sig 
+sigfile=$(mktemp)
+tpm2 sign -Q -p session:session.ctx -c 0x81000001 -f plain -o $sigfile 
 
-cat /tmp/sig
-rm -f /tmp/sig
+cat $sigfile
+rm -f $sigfile 

--- a/config/admin-functions/sign.sh
+++ b/config/admin-functions/sign.sh
@@ -1,0 +1,14 @@
+#!/bin/bash
+
+set -euo pipefail
+
+tpm2 startauthsession -Q -S session.ctx --policy-session
+tpm2_policypcr -Q -S session.ctx -l "sha256:0,2,4,5,7" --policy pcr.policy
+
+# This expects the script to be run with the data to be signed passed in via 
+# a here-string, e.g. sudo ./sign.sh <<< $(cat data.blob).
+# It "returns" the signature on stdout by catting a temporary file. 
+tpm2 sign -Q -p session:session.ctx -c 0x81000001 -f plain -o /tmp/sig 
+
+cat /tmp/sig
+rm -f /tmp/sig

--- a/config/sudoers
+++ b/config/sudoers
@@ -22,6 +22,7 @@ root	ALL=(ALL:ALL) ALL
 # fine-grained sudo permissions for certain users & actions
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/set-clock.sh
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/lockdown.sh
+vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/generate-key.sh
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/setup-boot-entry.sh
 vx-ui ALL=(root:ALL) NOPASSWD: /vx/code/config/admin-functions/timedatectl
 vx-ui ALL=(root:ALL) NOPASSWD: /usr/bin/brightnessctl

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -300,8 +300,8 @@ fi
 # setup tpm2-totp
 bash setup-scripts/setup-tpm2-totp.sh
 
-# setup signify
-bash setup-scripts/setup-signify.sh
+# setup tpm keys
+bash setup-scripts/setup-tpm2-tools.sh
 
 # permissions on directories
 # TODO: I think we only need to change the permissions for stuff in /var/ 

--- a/setup-scripts/setup-tpm2-tools.sh
+++ b/setup-scripts/setup-tpm2-tools.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+set -euo pipefail 
+
+sudo apt -y install tpm2-tools qrencode
+

--- a/vxdev/setup-vxdev-base-machine.sh
+++ b/vxdev/setup-vxdev-base-machine.sh
@@ -159,8 +159,8 @@ sudo cp vxdev/sudoers /etc/sudoers
 # setup tpm2-totp
 sudo bash setup-scripts/setup-tpm2-totp.sh
 
-# setup signify
-sudo bash setup-scripts/setup-signify.sh
+# setup tpm2-tools
+sudo bash setup-scripts/setup-tpm2-tools.sh
 
 # turn off time synchronization
 sudo timedatectl set-ntp no


### PR DESCRIPTION
This PR swaps out signify keys to tpm-based keys. 

I've tested this on VxAdmin, but not much else atm.

One question: the current PCR policy I'm using locks the keys to a specific kernel version. We could relax that constraint by using PCR-policy signing, or just dropping the kernel measurement PCR, but then we might be vulnerable to rollback attacks. The alternative is to just generate new keys every time we do a software update that modifies the kernel. 

I think in principle just locking the policy to PCR 0 (the TPM's unique ID) and PCR 7 (the Secure Boot policy) may give us enough of what we want, but I'm curious to know @benadida's thoughts. 