### PR TITLE
fix: remove --signify-secret-key

### DIFF
--- a/run-scripts/run-kiosk-browser.sh
+++ b/run-scripts/run-kiosk-browser.sh
@@ -17,5 +17,4 @@ kiosk-browser \
   --add-file-perm o=http://localhost:3000,p=/var/log/*,ro \
   --autoconfigure-print-config ${PRINTER_FILE} \
   --url ${URL} \
-  --signify-secret-key ${VX_CONFIG_ROOT}/key.sec
 

--- a/run-scripts/run-kiosk-browser.sh
+++ b/run-scripts/run-kiosk-browser.sh
@@ -16,5 +16,5 @@ kiosk-browser \
   --add-file-perm o=http://localhost:3000,p=/var/log,ro \
   --add-file-perm o=http://localhost:3000,p=/var/log/*,ro \
   --autoconfigure-print-config ${PRINTER_FILE} \
-  --url ${URL} \
+  --url ${URL}
 


### PR DESCRIPTION
Removes kiosk-browser's deprecated `--signify-secret-key` option from the `run-kiosk-browser.sh` script.