### PR TITLE
fix(setup): set the production machine hostname to VotingWorks.

### DIFF
--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -112,6 +112,9 @@ if [[ $DISTRO == "Debian" ]]; then
 	echo "export PATH=$PATH:/sbin" | sudo tee -a /etc/bash.bashrc
 fi
 
+# set a clean hostname
+hostnamectl set-hostname "VotingWorks"
+
 # turn off automatic updates
 sudo cp config/20auto-upgrades /etc/apt/apt.conf.d/
 


### PR DESCRIPTION
We're not setting the hostname anymore with machine ID, so let's at least set a hostname that isn't too confusing, or set to an IP address by default, when we setup a machine for production.