### PR TITLE
Fixup TPM code to be more robust to TPM firmware versions

### DIFF
--- a/config/admin-functions/generate-key.sh
+++ b/config/admin-functions/generate-key.sh
@@ -36,7 +36,8 @@ tpm2_evictcontrol -Q -c 0x81000001 || true 2>&1 /dev/null
 tpm2_evictcontrol -c key.ctx 0x81000001
 
 # Delete the local key files
-rm -rf key.pub key.priv
+rm -f key.pub 
+shred -u key.priv
 
 
 rm -f "${VX_CONFIG_ROOT}/key.pub" "${VX_CONFIG_ROOT}/key.sec"

--- a/config/admin-functions/generate-key.sh
+++ b/config/admin-functions/generate-key.sh
@@ -6,8 +6,15 @@ set -euo pipefail
 
 
 set -euo pipefail 
+
+# First detect whether the TPM supports sha1 or sha256
+algo="sha256"
+if [ $(tpm2 pcrread sha1:0 | wc -l) == 2 ]; then
+    algo="sha1"
+fi
+
 tpm2_startauthsession -S session.ctx
-tpm2_policypcr -S session.ctx -l "sha256:0,7" --policy pcr.policy
+tpm2_policypcr -S session.ctx -l "${algo}:0,7" --policy pcr.policy
 tpm2_createprimary -C o -c primary.ctx
 
 # Save the primary context for reuse after reboot
@@ -16,12 +23,16 @@ tpm2_createprimary -C o -c primary.ctx
 tpm2_evictcontrol -Q -c 0x81000000 || true 2>&1 /dev/null
 tpm2_evictcontrol -c primary.ctx 0x81000000
 
-# Create a policy
-tpm2_create -L pcr.policy -u key.pub -C primary.ctx -G ecc -c key.ctx
+# Create keys
+tpm2_create -L pcr.policy -u key.pub -r key.priv -C primary.ctx -G ecc 
+tpm2_load -u key.pub -r key.priv -C primary.ctx -c key.ctx
 
 # Save the keys
 tpm2_evictcontrol -Q -c 0x81000001 || true 2>&1 /dev/null
 tpm2_evictcontrol -c key.ctx 0x81000001
+
+# Delete the local key files
+rm -rf key.pub key.priv
 
 
 rm -f "${VX_CONFIG_ROOT}/key.pub" "${VX_CONFIG_ROOT}/key.sec"

--- a/config/admin-functions/generate-key.sh
+++ b/config/admin-functions/generate-key.sh
@@ -24,6 +24,10 @@ tpm2_evictcontrol -Q -c 0x81000000 || true 2>&1 /dev/null
 tpm2_evictcontrol -c primary.ctx 0x81000000
 
 # Create keys
+#
+# Note that the key.priv file is encrypted using the symmetric key stored at
+# the handle specified in primary.ctx. That symmetric key never leaves the TPM.
+# See man tpm2 create and man tpm2 createprimary for more information.
 tpm2_create -L pcr.policy -u key.pub -r key.priv -C primary.ctx -G ecc 
 tpm2_load -u key.pub -r key.priv -C primary.ctx -c key.ctx
 

--- a/config/ui-functions/sign.sh
+++ b/config/ui-functions/sign.sh
@@ -1,9 +1,14 @@
 #!/bin/bash
 
 set -euo pipefail
+# First detect whether the TPM supports sha1 or sha256
+algo="sha256"
+if [ $(tpm2 pcrread sha1:0 | wc -l) == 2 ]; then
+    algo="sha1"
+fi
 
 tpm2 startauthsession -Q -S session.ctx --policy-session
-tpm2_policypcr -Q -S session.ctx -l "sha256:0,7" --policy pcr.policy
+tpm2_policypcr -Q -S session.ctx -l "${algo}:0,7" --policy pcr.policy
 
 # This expects the script to be run with the data to be signed passed in via 
 # a here-string, e.g. sudo ./sign.sh <<< "a string"


### PR DESCRIPTION
* Adds support for both SHA1 and SHA256 PCR algorithms
* Doesn't rely on create-load feature, which is only supported on newer devices.