### PR TITLE
fix(timezone): store timezone in our normal config directory.

### DIFF
--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -350,8 +350,8 @@ fi
 
 # set up symlinked timezone files to prepare for read-only filesystem
 sudo rm -f /etc/localtime
-sudo ln -sf /usr/share/zoneinfo/America/Chicago /var/etc/localtime
-sudo ln -sf /var/etc/localtime /etc/localtime
+sudo ln -sf /usr/share/zoneinfo/America/Chicago /vx/config/localtime
+sudo ln -sf /vx/config/localtime /etc/localtime
 
 # remove all network drivers. Buh bye.
 sudo apt purge -y network-manager


### PR DESCRIPTION

Because our replacement `timedatectl` adapts to where we've symlinked the timezone, we only need to change where it's symlinked.