### PR TITLE
feat(terminal): bigger font

### DIFF
--- a/config/admin-functions/basic-configuration.sh
+++ b/config/admin-functions/basic-configuration.sh
@@ -28,12 +28,16 @@ PUBLIC_KEY=$(cat "${VX_CONFIG_ROOT}/key.pub")
 echo "Public Signing Key: ${PUBLIC_KEY}"
 echo "Record this QR code containing the Machine ID and Public Signing Key:"
 MACHINE_ID=$(< "${VX_CONFIG_ROOT}/machine-id")
+
+setfont /usr/share/consolefonts/Lat15-Terminus14.psf.gz 
 echo -e "${MACHINE_ID}\n${PUBLIC_KEY}" | qrencode -t ANSI -o -
 
 while true; do
     read -p "Confirm QR code recorded (y/n) " CONFIRM
     [[ "${CONFIRM}" = "y" ]] && break
 done
+setfont /usr/share/consolefonts/Lat15-TerminusBold24x12.psf.gz 
+
 
 if [[ -f "${VX_CONFIG_ROOT}/RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT" ]]; then
     rm -f "${VX_CONFIG_ROOT}/RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT"

--- a/config/admin-functions/show-vx-suite-admin-menu.sh
+++ b/config/admin-functions/show-vx-suite-admin-menu.sh
@@ -6,6 +6,9 @@ set -euo pipefail
 : "${VX_CONFIG_ROOT:="/vx/config"}"
 : "${VX_METADATA_ROOT:="/vx/code"}"
 
+# Large Font
+setfont /usr/share/consolefonts/Lat15-TerminusBold24x12.psf.gz 
+
 if [[ $(tty) = /dev/tty1 ]] && [[ -f "${VX_CONFIG_ROOT}/RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT" ]]; then
   "${VX_FUNCTIONS_ROOT}/basic-configuration.sh"
   exit 0
@@ -147,13 +150,17 @@ while true; do
     ;;
 
     generate-key)
+      setfont /usr/share/consolefonts/Lat15-Terminus14.psf.gz 
       sudo "${VX_FUNCTIONS_ROOT}/generate-key.sh"
       read -s -n 1
+      setfont /usr/share/consolefonts/Lat15-TerminusBold24x12.psf.gz 
     ;;
 
     show-key)
+      setfont /usr/share/consolefonts/Lat15-Terminus14.psf.gz 
       "${VX_FUNCTIONS_ROOT}/show-key.sh"
       read -s -n 1
+      setfont /usr/share/consolefonts/Lat15-TerminusBold24x12.psf.gz 
     ;;
     
     reset-totp)

--- a/config/console-setup
+++ b/config/console-setup
@@ -1,0 +1,16 @@
+# CONFIGURATION FILE FOR SETUPCON
+
+# Consult the console-setup(5) manual page.
+
+ACTIVE_CONSOLES="/dev/tty[1-6]"
+
+CHARMAP="UTF-8"
+
+CODESET="Lat15"
+FONTFACE="TerminusBold"
+FONTSIZE="24x12"
+
+VIDEOMODE=
+
+# The following is an example how to use a braille font
+# FONT='lat9w-08.psf.gz brl-8x8.psf'

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -123,6 +123,9 @@ sudo cp config/20auto-upgrades /etc/apt/apt.conf.d/
 # make sure machine never shuts down on idle, and does shut down on power key (no hibernate or anything.)
 sudo cp config/logind.conf /etc/systemd/
 
+# make terminal font bigger
+sudo cp config/console-setup /etc/default/
+
 echo "Creating necessary directories"
 # directory structure
 sudo mkdir -p /vx


### PR DESCRIPTION
This will apply to `tty1` for the wizard, and `tty2` for the menu.

This is not as clean as I'd like it to be, but it works and is fairly simple.

Tested on an L14 and on Surface Go, QR code fits.