### PR TITLE
add screenshot and recording apps to vxdev sidebar

### DIFF
--- a/vxdev/update-vxdev.sh
+++ b/vxdev/update-vxdev.sh
@@ -70,7 +70,7 @@ if [[ $CHOICE == 'VxAdminCentralScan' ]]; then
 fi
 
 # Set desktop icons as favorites so they appear in the doc
-gsettings set org.gnome.shell favorite-apps "[$FAVORITE_ICONS, 'update-code.desktop', 'update-vxdev.desktop','firefox-esr.desktop', 'org.gnome.Nautilus.desktop']"
+gsettings set org.gnome.shell favorite-apps "[$FAVORITE_ICONS, 'update-code.desktop', 'update-vxdev.desktop', 'org.gnome.Screenshot.desktop', 'firefox-esr.desktop', 'org.gnome.Nautilus.desktop', 'kazam.desktop']"
 
 CHOICE="${CHOICE}" sudo -E sh -c 'echo "${CHOICE}" > /vx/config/machine-type'
 

--- a/vxdev/vxdev-configuration.sh
+++ b/vxdev/vxdev-configuration.sh
@@ -21,7 +21,7 @@ sudo cp vxdev/update-vxdev.desktop /usr/share/applications/.
 # Set desktop background
 gsettings set org.gnome.desktop.background picture-uri file:///vx/votingworks-desktop.png
 # Set favorite apps
-gsettings set org.gnome.shell favorite-apps "['update-vxdev.desktop','firefox-esr.desktop', 'org.gnome.Nautilus.desktop']"
+gsettings set org.gnome.shell favorite-apps "['update-vxdev.desktop', 'org.gnome.Screenshot.desktop', 'firefox-esr.desktop', 'org.gnome.Nautilus.desktop', 'kazam.deskptop']"
 # Disable lock screen
 gsettings set org.gnome.desktop.lockdown disable-lock-screen 'true'
 


### PR DESCRIPTION
Adds the screenshot app and Kazam (screen recorder) to the default favorited apps in VxDev. The next image of VxDev will include Kazam installed, if it doesn't exist the icon just won't appear in the favorites list. 