### PR TITLE
Enable full debug logging in VxDev and route properly

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -50,7 +50,7 @@ if [[ " ${ALL_FRONTENDS[@]} " =~ " ${FRONTEND} " ]]; then
 
   export DISPLAY=${DISPLAY:-:0}
   cd "${DIR}/build/${FRONTEND}"
-  (trap 'kill 0' SIGINT SIGHUP; "./run-${FRONTEND}.sh" & ("./run-kiosk-browser.sh"; kill 0)) | logger --tag votingworksapp
+  (trap 'kill 0' SIGINT SIGHUP; "./run-${FRONTEND}.sh" & ("./run-kiosk-browser.sh"; kill 0)) 2>&1 | logger --tag votingworksapp
 elif [[ "${FRONTEND}" = -h || "${FRONTEND}" = --help ]]; then
   usage
   exit 0

--- a/vxdev/run-vxadmin.desktop
+++ b/vxdev/run-vxadmin.desktop
@@ -2,6 +2,6 @@
 Version=1.0
 Name=VxAdmin
 Icon=runprogram.png
-Exec=gnome-terminal -- /bin/sh -c 'env PATH=$PATH:/sbin env ADMIN_WORKSPACE=/vx/data/admin-service /vx/code/vxsuite-complete-system/run.sh election-manager'
+Exec=gnome-terminal -- /bin/sh -c 'env DEBUG=* env PATH=$PATH:/sbin env ADMIN_WORKSPACE=/vx/data/admin-service /vx/code/vxsuite-complete-system/run.sh election-manager'
 Terminal=false
 Type=Application

--- a/vxdev/run-vxcentralscan.desktop
+++ b/vxdev/run-vxcentralscan.desktop
@@ -2,6 +2,6 @@
 Version=1.0
 Name=VxCentralScan
 Icon=runprogram.png
-Exec=gnome-terminal -- /bin/sh -c 'env SCAN_WORKSPACE=/vx/data/module-scan env PATH=$PATH:/sbin /vx/code/vxsuite-complete-system/run.sh bsd'
+Exec=gnome-terminal -- /bin/sh -c 'env DEBUG=* env SCAN_WORKSPACE=/vx/data/module-scan env PATH=$PATH:/sbin /vx/code/vxsuite-complete-system/run.sh bsd'
 Terminal=false
 Type=Application

--- a/vxdev/run-vxmark.desktop
+++ b/vxdev/run-vxmark.desktop
@@ -2,6 +2,6 @@
 Version=1.0
 Name=VxMark
 Icon=runprogram.png
-Exec=gnome-terminal -- /bin/sh -c 'env PATH=$PATH:/sbin /vx/code/vxsuite-complete-system/run.sh bmd'
+Exec=gnome-terminal -- /bin/sh -c 'env DEBUG=* env PATH=$PATH:/sbin /vx/code/vxsuite-complete-system/run.sh bmd'
 Terminal=false
 Type=Application

--- a/vxdev/run-vxscan.desktop
+++ b/vxdev/run-vxscan.desktop
@@ -2,6 +2,6 @@
 Version=1.0
 Name=VxScan
 Icon=runprogram.png
-Exec=gnome-terminal -- /bin/sh -c 'env PATH=$PATH:/sbin env SCAN_WORKSPACE=/vx/data/module-scan /vx/code/vxsuite-complete-system/run.sh precinct-scanner'
+Exec=gnome-terminal -- /bin/sh -c 'env DEBUG=* env PATH=$PATH:/sbin env SCAN_WORKSPACE=/vx/data/module-scan /vx/code/vxsuite-complete-system/run.sh precinct-scanner'
 Terminal=false
 Type=Application


### PR DESCRIPTION
This turns on all internal debugging in VxDev automatically, and also fixes the run script such that if you run it with debugging on all of that debugging will automatically pipe to syslog/vx-logs properly instead of just outputting to the console. 

Confirmed that all the other logs were already being routed properly. 