### PR TITLE
Small VxDev Tweaks

### DIFF
--- a/vxdev/run-vxadmin.desktop
+++ b/vxdev/run-vxadmin.desktop
@@ -2,6 +2,6 @@
 Version=1.0
 Name=VxAdmin
 Icon=runprogram.png
-Exec=gnome-terminal -- /bin/sh -c 'env DEBUG=* env PATH=$PATH:/sbin env ADMIN_WORKSPACE=/vx/data/admin-service /vx/code/vxsuite-complete-system/run.sh election-manager'
+Exec=gnome-terminal -- /bin/sh -c 'env PATH=$PATH:/sbin env ADMIN_WORKSPACE=/vx/data/admin-service /vx/code/vxsuite-complete-system/run.sh election-manager'
 Terminal=false
 Type=Application

--- a/vxdev/run-vxcentralscan.desktop
+++ b/vxdev/run-vxcentralscan.desktop
@@ -2,6 +2,6 @@
 Version=1.0
 Name=VxCentralScan
 Icon=runprogram.png
-Exec=gnome-terminal -- /bin/sh -c 'env DEBUG=* env SCAN_WORKSPACE=/vx/data/module-scan env PATH=$PATH:/sbin /vx/code/vxsuite-complete-system/run.sh bsd'
+Exec=gnome-terminal -- /bin/sh -c 'env SCAN_WORKSPACE=/vx/data/module-scan env PATH=$PATH:/sbin /vx/code/vxsuite-complete-system/run.sh bsd'
 Terminal=false
 Type=Application

--- a/vxdev/run-vxmark.desktop
+++ b/vxdev/run-vxmark.desktop
@@ -2,6 +2,6 @@
 Version=1.0
 Name=VxMark
 Icon=runprogram.png
-Exec=gnome-terminal -- /bin/sh -c 'env DEBUG=* env PATH=$PATH:/sbin /vx/code/vxsuite-complete-system/run.sh bmd'
+Exec=gnome-terminal -- /bin/sh -c 'env PATH=$PATH:/sbin /vx/code/vxsuite-complete-system/run.sh bmd'
 Terminal=false
 Type=Application

--- a/vxdev/run-vxscan.desktop
+++ b/vxdev/run-vxscan.desktop
@@ -2,6 +2,6 @@
 Version=1.0
 Name=VxScan
 Icon=runprogram.png
-Exec=gnome-terminal -- /bin/sh -c 'env DEBUG=* env PATH=$PATH:/sbin env SCAN_WORKSPACE=/vx/data/module-scan /vx/code/vxsuite-complete-system/run.sh precinct-scanner'
+Exec=gnome-terminal -- /bin/sh -c 'env PATH=$PATH:/sbin env SCAN_WORKSPACE=/vx/data/module-scan /vx/code/vxsuite-complete-system/run.sh precinct-scanner'
 Terminal=false
 Type=Application

--- a/vxdev/update-code.sh
+++ b/vxdev/update-code.sh
@@ -74,15 +74,22 @@ cp /vx/config/.env.local vxsuite/.env.local
 make build-kiosk-browser
 echo $APP_TYPE
 if [[ $APP_TYPE == 'VxCentralScan' ]] || [[ $APP_TYPE == 'VxAdminCentralScan' ]]; then
+	cp /vx/config/.env.local vxsuite/services/scan/.env.local
+	cp /vx/config/.env.local vxsuite/frontends/bsd/.env.local
 	./build.sh bsd
 fi
 if [[ $APP_TYPE == 'VxAdmin' ]] || [[ $APP_TYPE == 'VxAdminCentralScan' ]]; then
+	cp /vx/config/.env.local vxsuite/frontends/election-manager/.env.local
+	cp /vx/config/.env.local vxsuite/services/admin/.env.local
 	./build.sh election-manager
 fi
 if [[ $APP_TYPE == 'VxMark' ]]; then
+	cp /vx/config/.env.local vxsuite/frontends/bmd/.env.local
 	./build.sh bmd
 fi
 if [[ $APP_TYPE == 'VxScan' ]]; then
+	cp /vx/config/.env.local vxsuite/services/scan/.env.local
+	cp /vx/config/.env.local vxsuite/frontends/precinct-scanner/.env.local
 	./build.sh precinct-scanner
 fi
 


### PR DESCRIPTION
Two Small improvements to VxDev 
1. Removes the debug=* flag when running the frontend apps, we added this for full logging but in practice there is SO MUCH logging it slows down the app on VxScan to basically be unusable. The other apps haven't seen as many issues but for consistency I think its better to just remove for now. 
2. Copies the vxdev env file for feature flags to all subrepos. Since the .env file on the subrepos overrides .env.local at the root VxDev users have struggled to set the feature flags properly. There are larger issues with the feature flagging to fix but this will at least make it so that setting things in /vx/config/.env.local will apply as you would expect. 

@amcmanus Don't expect you to review this but cc-ing you for visibility. More context on the env/feature flag conundrum: https://github.com/votingworks/vxsuite/issues/2796 