### PR TITLE
Support /apps directory structure (for VxScan) 

### DIFF
--- a/README.md
+++ b/README.md
@@ -66,7 +66,7 @@ SCAN_WORKSPACE=/tmp ./run.sh bsd
 
 You may replace `/tmp` with any persistent path you like.
 
-### Precinct Scanner (VxScan)
+### VxScan (Precinct Scanner)
 
 This requires some other packages to be installed that, unfortunately, are not
 public. If you have access, go to https://github.com/votingworks/plustekctl and
@@ -74,7 +74,7 @@ follow the install instructions. Once you've done that, this command will run
 all software services needed for precinct scanner:
 
 ```
-SCAN_WORKSPACE=/tmp ./run.sh precinct-scanner
+SCAN_WORKSPACE=/tmp ./run.sh vx-scan
 ```
 
 You may replace `/tmp` with any persistent path you like.
@@ -117,20 +117,10 @@ bash setup-machine.sh
 
 ## High-level Contracts
 
-Each front-end system, e.g. `bmd`, `bas`, etc., and each
-module, e.g. `module-smartcards`, `module-scan`, etc., should be an
+Each frontend app, e.g. `apps/vx-scan/frontend`, etc., and each
+service, e.g. `apps/vx-scan/backend`, `services/smartcards`, etc., should be an
 application that can be built using `make build`, and then run using
 `make run`.
-
-## Code Layout & Build
-
-Each component is a git submodule. We use submodules here because they
-are exactly what we need: a pointer to a particular commit of each of
-the combined repositories.
-
-We use git submodules here for the components, for the express purpose
-that we never want to update one of the components without explicitly
-checking that all the modules work well together.
 
 ## Acknowledgments
 

--- a/config/admin-functions/lockdown.sh
+++ b/config/admin-functions/lockdown.sh
@@ -6,7 +6,7 @@ set -euo pipefail
 
 # detect Surface Go
 #if dmidecode | grep -q 'Surface Go'; then
-if [[ $(cat "${VX_CONFIG_ROOT}/machine-type") == "precinct-scanner" ]]; then
+if [[ $(cat "${VX_CONFIG_ROOT}/machine-type") == "vx-scan" ]]; then
     surface=1
     echo "Detected a Precinct Scanner (Surface Go) device. Locking down with GRUB."
 else

--- a/config/vx-scan.service
+++ b/config/vx-scan.service
@@ -1,5 +1,5 @@
 [Unit]
-Description=VotingWorks Precinct Scanner
+Description=VotingWorks VxScan
 
 [Service]
 Type=simple
@@ -7,7 +7,7 @@ User=vx-services
 Environment=VX_CONFIG_ROOT=/vx/config
 Environment=VX_METADATA_ROOT=/vx/code
 Environment=SCAN_WORKSPACE=/vx/data/module-scan
-ExecStart=/bin/bash /vx/services/run-precinct-scanner.sh
+ExecStart=/bin/bash /vx/services/run-vx-scan.sh
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=votingworksapp

--- a/run-scripts/run-kiosk-browser-forever-and-log.sh
+++ b/run-scripts/run-kiosk-browser-forever-and-log.sh
@@ -13,7 +13,7 @@ source ${CONFIG}/read-vx-machine-config.sh
 : "${VX_MACHINE_TYPE:=""}"
 
 # remove pointer on screen
-if [ "${VX_MACHINE_TYPE}" = "bmd" ] || [ "${VX_MACHINE_TYPE}" = "bas" ] || [ "${VX_MACHINE_TYPE}" = "precinct-scanner" ]; then
+if [ "${VX_MACHINE_TYPE}" = "bmd" ] || [ "${VX_MACHINE_TYPE}" = "bas" ] || [ "${VX_MACHINE_TYPE}" = "vx-scan" ]; then
     unclutter -idle 0.01 -root &
 fi
     
@@ -23,7 +23,7 @@ if [ "${VX_MACHINE_TYPE}" = "bmd" ]; then
 fi
 
 # Max out volume for sound effects
-if [ "${VX_MACHINE_TYPE}" = "precinct-scanner" ]; then
+if [ "${VX_MACHINE_TYPE}" = "vx-scan" ]; then
     amixer -D pulse set Master 100% || true
 fi
 

--- a/run-scripts/run-vx-scan.sh
+++ b/run-scripts/run-vx-scan.sh
@@ -17,4 +17,4 @@ fi
 
 export PIPENV_VENV_IN_PROJECT=1
 export NODE_ENV=production
-(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/services/scan run & make -C vxsuite/services/smartcards run & make -C vxsuite/frontends/precinct-scanner run) | logger --tag votingworksapp
+(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/vx-scan/backend run & make -C vxsuite/services/smartcards run & make -C vxsuite/apps/vx-scan/frontend run) | logger --tag votingworksapp

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -46,7 +46,7 @@ CHOICES+=('bas')
 MODEL_NAMES+=('VxEncode')
 
 echo "${#CHOICES[@]}. Precinct Scanner"
-CHOICES+=('precinct-scanner')
+CHOICES+=('vx-scan')
 MODEL_NAMES+=('VxScan')
 
 echo
@@ -84,7 +84,7 @@ echo "The script will take it from here and set up the machine."
 echo
 
 # pre-flight checks to ensure we have everything we need
-if [ "${CHOICE}" == "precinct-scanner" ]
+if [ "${CHOICE}" == "vx-scan" ]
 then
     if ! which plustekctl >/dev/null 2>&1
     then

--- a/vxdev/run-vxscan.desktop
+++ b/vxdev/run-vxscan.desktop
@@ -2,6 +2,6 @@
 Version=1.0
 Name=VxScan
 Icon=runprogram.png
-Exec=gnome-terminal -- /bin/sh -c 'env PATH=$PATH:/sbin env SCAN_WORKSPACE=/vx/data/module-scan /vx/code/vxsuite-complete-system/run.sh precinct-scanner'
+Exec=gnome-terminal -- /bin/sh -c 'env PATH=$PATH:/sbin env SCAN_WORKSPACE=/vx/data/module-scan /vx/code/vxsuite-complete-system/run.sh vx-scan'
 Terminal=false
 Type=Application

--- a/vxdev/update-code.sh
+++ b/vxdev/update-code.sh
@@ -89,8 +89,8 @@ if [[ $APP_TYPE == 'VxMark' ]]; then
 fi
 if [[ $APP_TYPE == 'VxScan' ]]; then
 	cp /vx/config/.env.local vxsuite/services/scan/.env.local
-	cp /vx/config/.env.local vxsuite/frontends/precinct-scanner/.env.local
-	./build.sh precinct-scanner
+	cp /vx/config/.env.local vxsuite/apps/vx-scan/frontend/.env.local
+	./build.sh vx-scan
 fi
 
 echo "Done! Closing in 3 seconds."


### PR DESCRIPTION
Task: https://github.com/votingworks/vxsuite/issues/2813

Due to the changes in https://github.com/votingworks/vxsuite/pull/2816 which change the vxsuite directory structure for VxScan, scripts in this repo needed to be updated accordingly.

_Review by commits_

Tested by:
- Running `./build.sh vx-scan`
- Running `./run.sh vx-scan`

I know we should probably also test the consumers of those scripts (which also got updated) but I wasn't sure how to test them.