### PR TITLE
run.sh: Delay kiosk-browser to let app start first

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -62,7 +62,12 @@ if [[ " ${ALL_APPS_AND_FRONTENDS[@]} " =~ " ${APP} " ]]; then
 
   export DISPLAY=${DISPLAY:-:0}
   cd "${DIR}/build/${APP}"
-  (trap 'kill 0' SIGINT SIGHUP; "./run-${APP}.sh" & ("./run-kiosk-browser.sh"; kill 0)) 2>&1 | logger --tag votingworksapp
+  (
+    trap 'kill 0' SIGINT SIGHUP; "./run-${APP}.sh" &
+    # Delay kiosk-browser a bit to make sure the app is running first, otherwise
+    # kiosk-browser will fail to load the app and need a manual refresh (Ctrl-R)
+    (sleep 1s; "./run-kiosk-browser.sh"; kill 0)
+  ) 2>&1 | logger --tag votingworksapp
 elif [[ "${APP}" = -h || "${APP}" = --help ]]; then
   usage
   exit 0

--- a/run.sh
+++ b/run.sh
@@ -64,9 +64,8 @@ if [[ " ${ALL_APPS_AND_FRONTENDS[@]} " =~ " ${APP} " ]]; then
   cd "${DIR}/build/${APP}"
   (
     trap 'kill 0' SIGINT SIGHUP; "./run-${APP}.sh" &
-    # Delay kiosk-browser a bit to make sure the app is running first, otherwise
-    # kiosk-browser will fail to load the app and need a manual refresh (Ctrl-R)
-    (sleep 1s; "./run-kiosk-browser.sh"; kill 0)
+    # Delay kiosk-browser to make sure the app is running first
+    (while ! curl -s localhost:3000; do sleep 1; done; "./run-kiosk-browser.sh"; kill 0)
   ) 2>&1 | logger --tag votingworksapp
 elif [[ "${APP}" = -h || "${APP}" = --help ]]; then
   usage


### PR DESCRIPTION
When using run.sh, I was noticing that kiosk-browser would show an empty white screen and have the following error in the logs (/var/log/syslog):

```
electron: Failed to load URL: http://localhost:3000/ with error: ERR_CONNECTION_REFUSED
```

Delaying kiosk-browser with a sleep seemed to fix the issue, which indicates that the root cause may be that kiosk-browser is trying to load the page before the app frontend server is running. While this isn't a great long-term fix, it may suffice for now.