### PR TITLE
Add `sudo` permissions for USB Formatting

### DIFF
--- a/config/sudoers
+++ b/config/sudoers
@@ -29,4 +29,7 @@ vx-ui ALL=(root:ALL) NOPASSWD: /usr/bin/brightnessctl
 vx-ui ALL=(root:ALL) NOPASSWD: /usr/local/bin/tpm2-totp
 vx-ui ALL=(root:ALL) NOPASSWD: /vx/ui/ui-functions/sign.sh
 vx-ui ALL=(root:ALL) NOPASSWD: /bin/efibootmgr
+vx-ui ALL=(root:ALL) NOPASSWD: /usr/sbin/sfdisk
+vx-ui ALL=(root:ALL) NOPASSWD: /usr/sbin/mkfs.fat
+vx-ui ALL=(root:ALL) NOPASSWD: /usr/sbin/mkfs.exfat
 vx-admin ALL=(root:ALL) NOPASSWD: /usr/local/bin/tpm2-totp


### PR DESCRIPTION
We don't need to add the dependencies here (for now) because they will go in the `Makefile` in `vxsuite` for the particular apps.