### PR TITLE
fix missed rename from bmd to vxmark

### DIFF
--- a/vxdev/update-code.sh
+++ b/vxdev/update-code.sh
@@ -86,7 +86,7 @@ fi
 if [[ $APP_TYPE == 'VxMark' ]]; then
 	cp /vx/config/.env.local vxsuite/apps/vx-mark/frontend/.env.local
 	cp /vx/config/.env.local vxsuite/apps/vx-mark/backend/.env.local
-	./build.sh bmd
+	./build.sh vx-mark
 fi
 if [[ $APP_TYPE == 'VxScan' ]]; then
 	cp /vx/config/.env.local vxsuite/apps/vx-scan/backend/.env.local


### PR DESCRIPTION
Missed this place to update to the vx-mark name for VxDev 