### PR TITLE
Adam/fix build packages

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -28,6 +28,9 @@ ALL_APPS=()
 
 for app in ${DIR}/vxsuite/apps/*; do
   if [ -d "${app}" ]; then
+    tmp_dir=$(basename "${app}")
+    make -C "${DIR}/vxsuite/apps/${tmp_dir}/frontend" install
+    make -C "${DIR}/vxsuite/apps/${tmp_dir}/backend" install
     ALL_APPS+=("$(basename "${app}")")
   fi
 done
@@ -38,12 +41,16 @@ ALL_SERVICES=()
 
 for app in ${DIR}/vxsuite/frontends/*; do
   if [ -d "${app}" ]; then
+    tmp_dir=$(basename "${app}")
+    make -C "${DIR}/vxsuite/frontends/${tmp_dir}" install
     ALL_FRONTENDS+=("$(basename "${app}")")
   fi
 done
 
 for app in ${DIR}/vxsuite/services/*; do
   if [ -d "${app}" ]; then
+    tmp_dir=$(basename "${app}")
+    make -C "${DIR}/vxsuite/services/${tmp_dir}" install
     ALL_SERVICES+=("$(basename "${app}")")
   fi
 done
@@ -68,18 +75,8 @@ build() {
     set -euo pipefail
 
     if [ -d "${DIR}/vxsuite/frontends/${APP}" ]; then
-      for service in "${ALL_SERVICES[@]}"; do
-        make -C "${DIR}/vxsuite/services/${service}" install
-      done
-      for frontend in "${ALL_FRONTENDS[@]}"; do
-        make -C "${DIR}/vxsuite/frontends/${frontend}" install
-      done
       cd "${DIR}/vxsuite/frontends/${APP}"
     else
-      for app in "${ALL_APPS[@]}"; do
-        make -C "${DIR}/vxsuite/apps/${app}/frontend" install
-        make -C "${DIR}/vxsuite/apps/${app}/backend" install
-      done
       cd "${DIR}/vxsuite/apps/${APP}/frontend"
     fi
 

--- a/setup-node.sh
+++ b/setup-node.sh
@@ -10,5 +10,5 @@ echo "deb-src https://deb.nodesource.com/${NODE_VERSION} ${DISTRO} main" | sudo 
 sudo apt update
 sudo apt install -y nodejs
 
-sudo npm install -g yarn pnpm@5
+sudo npm install -g yarn pnpm@7
 


### PR DESCRIPTION
re: `setup-node.sh` - we have moved to pnpm v7, need to update.

re: `build.sh` - Our current approach to installing system-level packages relies heavily on Makefile directives, specifically `make install`. This tight coupling has resulted in fragile builds as the structure of the https://github.com/votingworks/vxsuite repo changes over time. In an effort to minimize those issues in the near-term, this change does two things:

1. Runs `make install` across all apps, services, and frontends upfront. This should ensure all system-level packages are installed before we ever build the individual components.
2. Eliminates repeated package installs within the looping constructs of the `build()` function. Even though repeated attempts are effectively no-ops, this reduces build time and potential failures since we only need to install packages once.