### PR TITLE
fix(setup-machine): review home partition for vx-ui

### DIFF
--- a/config/xinitrc
+++ b/config/xinitrc
@@ -5,7 +5,7 @@ xrdb ~/.Xresources
 
 export VX_CONFIG_ROOT="/vx/config"
 export VX_METADATA_ROOT="/vx/code"
-bash /vx/ui/.vx/run-kiosk-browser-forever-and-log.sh &
+bash /vx/code/run-kiosk-browser-forever-and-log.sh &
 
 # brightness all the way
 sudo brightnessctl s 100%


### PR DESCRIPTION
turns out, we have trouble running X as `vx-ui` if homedir is immutable. We'll have to find a better way to do this later, but for now, reenabling lockdown / read-only root partition with this change. Using the opportunity to simplify things a tad, we don't need `/vx/ui/.vx`, and we don't need to rebuild the code in `setup-machine`.