### PR TITLE
Upgrade pnpm

### DIFF
--- a/setup-node.sh
+++ b/setup-node.sh
@@ -10,5 +10,5 @@ echo "deb-src https://deb.nodesource.com/${NODE_VERSION} ${DISTRO} main" | sudo 
 sudo apt update
 sudo apt install -y nodejs
 
-sudo npm install -g yarn pnpm@7
+sudo npm install -g yarn pnpm@8.1.0
 


### PR DESCRIPTION
The vxsuite-complete-system analog of https://github.com/votingworks/vxsuite-build-system/pull/34. While we're still in the middle of the transition to vxsuite-build-system, let's make sure all pnpm installers install 8.1.0.