### PR TITLE
making home read-only and making X compatible with it

### DIFF
--- a/config/admin-functions/generate-key.sh
+++ b/config/admin-functions/generate-key.sh
@@ -10,39 +10,45 @@ if [ "$(tpm2 pcrread sha256:0 | wc -l)" == "2" ]; then
     algo="sha256"
 fi
 
-tpm2_startauthsession -S session.ctx
-tpm2_policypcr -S session.ctx -l "${algo}:0,7" --policy pcr.policy
-tpm2_createprimary -C o -c primary.ctx
+# do all TPM actions in a subshell so as to control directory where everything is happening
+(
+    cd /tmp
+    
+    tpm2_startauthsession -S session.ctx
+    tpm2_policypcr -S session.ctx -l "${algo}:0,7" --policy pcr.policy
+    tpm2_createprimary -C o -c primary.ctx
+    
+    # Save the primary context for reuse after reboot
+    # First make sure nothing is in the handle we want to save our primary context
+    # to
+    tpm2_evictcontrol -Q -c 0x81000000 &> /dev/null || true
+    tpm2_evictcontrol -c primary.ctx 0x81000000
+    
+    # Create keys
+    #
+    # Note that the key.priv file is encrypted using the symmetric key stored at
+    # the handle specified in primary.ctx. That symmetric key never leaves the TPM.
+    # See man tpm2 create and man tpm2 createprimary for more information.
+    #
+    # A password isn't required for our security model, just required by OpenSSL,
+    # hence the dummy password.
+    tpm2_create -L pcr.policy -u key.pub -r key.priv -C primary.ctx -G ecc -p password
+    tpm2_load -u key.pub -r key.priv -C primary.ctx -c key.ctx
+    
+    # Save the keys
+    tpm2_evictcontrol -Q -c 0x81000001 &> /dev/null || true
+    tpm2_evictcontrol -c key.ctx 0x81000001
+    
+    # Delete the local key files
+    rm -f key.pub 
+    shred -u key.priv
 
-# Save the primary context for reuse after reboot
-# First make sure nothing is in the handle we want to save our primary context
-# to
-tpm2_evictcontrol -Q -c 0x81000000 &> /dev/null || true
-tpm2_evictcontrol -c primary.ctx 0x81000000
+    
+    rm -f "${VX_CONFIG_ROOT}/key.pub" "${VX_CONFIG_ROOT}/key.sec"
+    tpm2_readpublic -c key.ctx -f PEM -o "${VX_CONFIG_ROOT}/key.pub"
+)
 
-# Create keys
-#
-# Note that the key.priv file is encrypted using the symmetric key stored at
-# the handle specified in primary.ctx. That symmetric key never leaves the TPM.
-# See man tpm2 create and man tpm2 createprimary for more information.
-#
-# A password isn't required for our security model, just required by OpenSSL,
-# hence the dummy password.
-tpm2_create -L pcr.policy -u key.pub -r key.priv -C primary.ctx -G ecc -p password
-tpm2_load -u key.pub -r key.priv -C primary.ctx -c key.ctx
-
-# Save the keys
-tpm2_evictcontrol -Q -c 0x81000001 &> /dev/null || true
-tpm2_evictcontrol -c key.ctx 0x81000001
-
-# Delete the local key files
-rm -f key.pub 
-shred -u key.priv
-
-
-rm -f "${VX_CONFIG_ROOT}/key.pub" "${VX_CONFIG_ROOT}/key.sec"
-tpm2_readpublic -c key.ctx -f PEM -o "${VX_CONFIG_ROOT}/key.pub"
 
 chmod +r "${VX_CONFIG_ROOT}/key.pub"
-
 cat "${VX_CONFIG_ROOT}/key.pub" | qrencode -t ANSI -o -
+

--- a/config/admin-functions/make-root-readonly.sh
+++ b/config/admin-functions/make-root-readonly.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# the extra space at the start of the regexp is to make this idempotent
+sed -i 's/ errors=remount/ ro,errors=remount/' /etc/fstab

--- a/config/admin-functions/show-vx-suite-admin-menu.sh
+++ b/config/admin-functions/show-vx-suite-admin-menu.sh
@@ -59,6 +59,9 @@ while true; do
   echo "${#CHOICES[@]}. Run Basic Configuration Wizard On Next Boot"
   CHOICES+=('basic-configuration-on-next-boot')
 
+  echo "${#CHOICES[@]}. Reboot to Admin Menu for Lockdown"
+  CHOICES+=('lockdown-on-next-boot')
+
   echo
   echo -e "\e[1mAdvanced\e[0m"
   echo "${#CHOICES[@]}. Set Machine ID"
@@ -123,8 +126,14 @@ while true; do
     ;;
 
     basic-configuration-on-next-boot)
-      touch "${VX_CONFIG_ROOT}/RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT"
-    ;;
+	touch "${VX_CONFIG_ROOT}/RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT"
+      ;;
+
+    lockdown-on-next-boot)
+	touch "${VX_CONFIG_ROOT}/RUN_LOCKDOWN_ON_NEXT_BOOT"
+	sudo "${VX_FUNCTIONS_ROOT}/make-root-readonly.sh"
+	prompt-to-restart
+      ;;
 
     set-machine-id)
       "${VX_FUNCTIONS_ROOT}/choose-vx-machine-id.sh"

--- a/config/admin_bash_profile
+++ b/config/admin_bash_profile
@@ -1,5 +1,8 @@
 export PATH=/vx/code/config/admin-functions:${PATH}
 
+# remove the lockdown trigger on login
+rm -f /vx/config/RUN_LOCKDOWN_ON_NEXT_BOOT
+
 while true; do
     bash /vx/admin/admin-functions/show-vx-suite-admin-menu.sh
 done

--- a/config/autologin.sh
+++ b/config/autologin.sh
@@ -3,11 +3,16 @@
 # This script is designed to be run in override.conf file for the service getty@tty1.
 # It conditionally selects which user to autologin based on whether or not the
 # machine needs configuration.
+USER=vx-ui
+
 if [[ -f /vx/config/RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT ]]; then
     USER=vx-admin
-else
-    USER=vx-ui
 fi
+
+if [[ -f /vx/config/RUN_LOCKDOWN_ON_NEXT_BOOT ]]; then
+    USER=vx-admin
+fi
+
 # For the getty service, you can't have any nested processes, thus we use exec to
 # make mingetty take over the process of this script.
 exec /sbin/mingetty --autologin $USER --noclear $1

--- a/config/sudoers
+++ b/config/sudoers
@@ -21,6 +21,7 @@ root	ALL=(ALL:ALL) ALL
 
 # fine-grained sudo permissions for certain users & actions
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/set-clock.sh
+vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/make-root-readonly.sh
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/lockdown.sh
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/generate-key.sh
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/setup-boot-entry.sh

--- a/config/sudoers-for-dev
+++ b/config/sudoers-for-dev
@@ -22,6 +22,7 @@ vx-admin	ALL=(ALL:ALL) ALL
 
 # fine-grained sudo permissions for certain users & actions
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/set-clock.sh
+vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/make-root-readonly.sh
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/lockdown.sh
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/generate-key.sh
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/setup-boot-entry.sh

--- a/config/ui_bash_profile
+++ b/config/ui_bash_profile
@@ -1,7 +1,7 @@
-export PATH=/vx/code/config/admin-functions:${PATH}
+export PATH=/vx/code/config/admin-functions:/sbin:${PATH}
 
 if [[ $(tty) = /dev/tty1 ]]; then
-   exec startx
+   # if startx crashes or quits for any reason, log out
+   XAUTHORITY=/tmp/.Xauthority startx || logout
 fi
 
-export PATH=$PATH:/sbin

--- a/production-preseed.cfg
+++ b/production-preseed.cfg
@@ -255,7 +255,7 @@ d-i partman-auto/expert_recipe string     \
     filesystem{ ext2 }                     \
     mountpoint{ /boot }                   \
     .                                     \
-    8000 800 8000 ext4                    \
+    19000 4000 19000 ext4                    \
     \$lvmok{ }                            \
     method{ format }                      \
     format{ }                             \
@@ -275,13 +275,6 @@ d-i partman-auto/expert_recipe string     \
     format{ }                             \
    use_filesystem{ } filesystem{ ext4 }     \
     mountpoint{ /tmp }                    \
-    .                                     \
-    11000 3000 11000 ext4                   \
-    \$lvmok{ }                            \
-    method{ format }                      \
-    format{ }                             \
-    use_filesystem{ } filesystem{ ext4 }    \
-    mountpoint{ /home }                   \
     .                                     \
     1000 300 1000 ext4                    \
     \$lvmok{ }                            \


### PR DESCRIPTION

This makes all home directories read-only as follows:
- remove the separate `/home` partition, it's now part of `/` – update the pre-seed accordingly
- tell Xwindows to use `/tmp/.Xauthority` as its lock file
- give a writable space for `/vx/ui/.local` so X can log there to its heart's content
- make sure all home directories are now at `/vx/...` rather than `/var/vx/...`

While we're at it:
- remove some permissions so it's harder for `vx-ui` to run a node executable. (This needs more work, but it's a start.)

The changes above make it more difficult to lock down, because the lockdown procedure requires remounting `/` as read-only, and that can't happen when we're using files in `/`, which we now are cause that includes the home directories.

So lockdown is now in two phases:
- from `tty2` menu, choose lock down on next reboot, which sets a flag and updates `fstab` to remount `/` as read-only
- on next boot, menu automatically comes up, choose option to lock down. That performs the actual lockdown, and since `/` is already mounted read-only, all is well.