### PR TITLE
Final tweaks in preparation for m17a CISA builds

### DIFF
--- a/config/admin-functions/mock-vx-certifier.sh
+++ b/config/admin-functions/mock-vx-certifier.sh
@@ -4,7 +4,7 @@
 # terminal. Should be run from the root of vxsuite-complete-system, with a USB plugged in, after
 # create-machine-cert.sh has written a CSR to the USB.
 #
-# Usage: sudo ./config/admin-functions/mock-vx-certifier.sh
+# Usage: sudo VX_PRIVATE_KEY_PATH=/path/to/vx-private-key.pem ./config/admin-functions/mock-vx-certifier.sh
 
 set -euo pipefail
 
@@ -41,8 +41,8 @@ fi
 
 if [[ "${VX_MACHINE_TYPE}" = "admin" ]]; then
     openssl x509 -req \
-        -CA ./vxsuite/libs/auth/certs/dev/vx-cert-authority-cert.pem \
-        -CAkey ./vxsuite/libs/auth/certs/dev/vx-private-key.pem \
+        -CA ./vxsuite/libs/auth/certs/prod/vx-cert-authority-cert.pem \
+        -CAkey "${VX_PRIVATE_KEY_PATH}" \
         -CAcreateserial \
         -CAserial "${SERIAL_FILE}" \
         -in "${USB_CERTS_DIRECTORY}/csr.pem" \
@@ -51,8 +51,8 @@ if [[ "${VX_MACHINE_TYPE}" = "admin" ]]; then
         -out "${USB_CERTS_DIRECTORY}/cert.pem"
 else
     openssl x509 -req \
-        -CA ./vxsuite/libs/auth/certs/dev/vx-cert-authority-cert.pem \
-        -CAkey ./vxsuite/libs/auth/certs/dev/vx-private-key.pem \
+        -CA ./vxsuite/libs/auth/certs/prod/vx-cert-authority-cert.pem \
+        -CAkey "${VX_PRIVATE_KEY_PATH}" \
         -CAcreateserial \
         -CAserial "${SERIAL_FILE}" \
         -in "${USB_CERTS_DIRECTORY}/csr.pem" \


### PR DESCRIPTION
Some final tweaks in preparation for m17a CISA builds, namely around using a new root key pair and cert in prod rather than the dev ones. This required one more vxsuite submodule bump (to pull in [this change](https://github.com/votingworks/vxsuite/commit/49fa5dc34f15582374af64a330305a098e727e75)) and a tweak to the `mock-vx-certifier.sh` script.