### PR TITLE
Brother PJ-822 Printer Config Part 2.

### DIFF
--- a/printing/debian-printer-autoconfigure.json
+++ b/printing/debian-printer-autoconfigure.json
@@ -27,6 +27,15 @@
       "ppd": {
         "path": "generic-postscript-driver.ppd"
       }
+    },
+    {
+      "label": "Brother PJ-822",
+      "vendorId": 1273,
+      "productId": 8418,
+      "baseDeviceURI": "usb://Brother/PJ-822",
+      "ppd": {
+        "path": "brother_pj822_printer_en.ppd"
+      }
     }
   ]
 }


### PR DESCRIPTION
In #318, I added the PJ-822 config to the old auto-configure file for printing rather than the new one, for Debian. Perhaps we should axe the old one to avoid this mistake again?