### PR TITLE
Fix check for whether vx-admin user should have sudo privileges

### DIFF
--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -377,7 +377,7 @@ sudo hostnamectl set-hostname "VotingWorks"
 sudo sh -c 'echo "\n127.0.1.1\tVotingWorks" >> /etc/hosts'
 
 # move in our sudo file, which removes sudo'ing except for granting vx-admin a very specific set of privileges
-if [[ $VXADMIN_SUDO ]] ; then
+if [[ "${VXADMIN_SUDO}" == 1 ]] ; then
     sudo cp config/sudoers-for-dev /etc/sudoers
 else
     sudo cp config/sudoers /etc/sudoers


### PR DESCRIPTION
However we answer the `Finally, do you want sudo privileges for vx-admin (only for dev purposes)? [y/N]` prompt, the vx-admin user is always given sudo privileges because of a bug in this check:

https://github.com/votingworks/vxsuite-complete-system/blob/c2196d51ac7161ec92f124e2a07122bb7b903012/setup-machine.sh#L380-L384

The `if [[ $VXADMIN_SUDO ]]` condition will be met even if `VXADMIN_SUDO` is set to `0` here:

https://github.com/votingworks/vxsuite-complete-system/blob/c2196d51ac7161ec92f124e2a07122bb7b903012/setup-machine.sh#L79-L87

Here's a simple test that you can run in a bash shell:

```
$ if [[ 0 ]]; then echo oops; fi
oops
```

This PR corrects the check ✅