### PR TITLE
Tweak TPM + OpenSSL setup for Debian 12 / OpenSSL 3

### DIFF
--- a/config/admin-functions/generate-key.sh
+++ b/config/admin-functions/generate-key.sh
@@ -26,9 +26,10 @@ tpm2_evictcontrol -c primary.ctx 0x81000000
 # the handle specified in primary.ctx. That symmetric key never leaves the TPM.
 # See man tpm2 create and man tpm2 createprimary for more information.
 #
-# A password isn't required for our security model, just required by OpenSSL,
-# hence the dummy password.
-tpm2_create -L pcr.policy -u key.pub -r key.priv -C primary.ctx -G ecc -p password
+# We explicitly set the password for the key to the empty string (-p ''). A
+# password isn't necessary for our security model, but if no password is
+# specified at all, OpenSSL errs when using the key.
+tpm2_create -L pcr.policy -u key.pub -r key.priv -C primary.ctx -G ecc -p ''
 tpm2_load -u key.pub -r key.priv -C primary.ctx -c key.ctx
 
 # Save the keys

--- a/setup-scripts/setup-tpm2-tools.sh
+++ b/setup-scripts/setup-tpm2-tools.sh
@@ -2,11 +2,4 @@
 
 set -euo pipefail 
 
-# libengine-tpm2-tss-openssl is found in bullseye-backports, which we add here but assign the
-# lowest possible priority to, to ensure that we only pull from it when absolutely necessary
-sudo sh -c 'echo "\ndeb http://http.us.debian.org/debian bullseye-backports main" >> /etc/apt/sources.list'
-sudo sh -c 'echo "Package: *\nPin: release a=bullseye-backports\nPin-Priority: 1" >> /etc/apt/preferences.d/bullseye-backports'
-sudo apt update
-
-sudo apt -y install tpm2-tools qrencode
-sudo apt -y -t bullseye-backports install libengine-tpm2-tss-openssl
+sudo apt install -y tpm2-tools tpm2-openssl qrencode


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/3822

We're upgrading from Debian 11 to Debian 12, which under the hood upgrades OpenSSL from version 1.1.1 to 3. It also just so happens that OpenSSL 1.1.1 reached its end of life this week 😅.

This PR updates a dependency and how we initialize the TPM keys to account for the upgrade. The changes go hand-in-hand with https://github.com/votingworks/vxsuite/pull/3965.

## Testing

Used a ThinkPad, imaged with Debian 12, to identify and test the necessary changes.

For reference @amcmanus, here are the commands that I ran after installing vanilla Debian 12 to get the TPM + OpenSSL to a working state.

```
# Clone vxsuite-complete-system and check out this branch plus its analog in vxsuite
git clone https://github.com/votingworks/vxsuite-complete-system.git
cd vxsuite-complete-system
git checkout arsalan/debian-12-updates
git submodule update --init
cd vxsuite
git checkout arsalan/debian-12-updates
cd ..

# Install dependencies
sudo bash setup-scripts/setup-tpm2-tools.sh
sudo bash setup-scripts/setup-tpm2-totp.sh

# Generate TPM keys as the machine configuration wizard would
sudo mkdir -p /vx/config
sudo config/admin-functions/generate-key.sh
```

From here, I was successfully able to use the TPM + OpenSSL through vxsuite code for the following operations:
- [x] Generating a cert signing request (relevant for machine cert creation)
- [x] Generating a cert (relevant for smart card programming)
- [x] Signing a message (relevant for artifact authentication)