### PR TITLE
build: run all `install:rust-addon` scripts

### DIFF
--- a/prepare_build.sh
+++ b/prepare_build.sh
@@ -96,7 +96,7 @@ build() {
 }
 
 echo "Download all Rust crates"
-pnpm --dir ${DIR}/vxsuite/libs/ballot-interpreter/ install:rust-addon
+pnpm --recursive install:rust-addon
 
 echo "Download all kiosk-browser tools"
 make -C kiosk-browser install


### PR DESCRIPTION
Right now this only exists in `libs/ballot-interpreter`, but if that changes we'd have to update this. With this change we can add or rename packages as long as they have this script.