### PR TITLE
Updates our log configuration to support VVSG2.0 requirements

### DIFF
--- a/config/30-votingworks.conf
+++ b/config/30-votingworks.conf
@@ -9,10 +9,10 @@ template(name="jsonfmt" type="list") {
  }
 
 # reformat json messages into one json blob and send to vx-logs.log
-if $programname == "votingworksapp" and re_match($msg,'^ *\\{.*\\} *$') then /var/log/vx-logs.log;jsonfmt
+if $programname == "votingworksapp" and re_match($msg,'^ *\\{.*\\} *$') then /var/log/votingworks/vx-logs.log;jsonfmt
 &stop # excludes the messages matched above from being matched by other rules
 # send all other non-json messages from votingworksapp to the main syslog
-if $programname == "votingworksapp" then -/var/log/syslog
+if $programname == "votingworksapp" then -/var/log/votingworks/syslog
 
 template(name="usbDeviceInformation" type="list" option.jsonf="on") {
          property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")
@@ -25,7 +25,7 @@ template(name="usbDeviceInformation" type="list" option.jsonf="on") {
          constant(outname="disposition" value="na" format="jsonf")
  }
 
-if $programname == "kernel" and ($msg startsWith "usb") then /var/log/vx-logs.log;usbDeviceInformation
+if $programname == "kernel" and ($msg startsWith "usb") then /var/log/votingworks/vx-logs.log;usbDeviceInformation
 
 # Handle routing of system logs
 
@@ -51,8 +51,8 @@ template(name="machineBootSuccess" type="list" option.jsonf="on") {
          property(outname="message" name="msg" format="jsonf")
  }
 
-if $programname == "kernel" and $msg startswith "Command line: BOOT_IMAGE" then /var/log/vx-logs.log;machineBootInit
-if $syslogtag == "systemd[1]:" and $msg contains "Startup finished" then /var/log/vx-logs.log;machineBootSuccess
+if $programname == "kernel" and $msg startswith "Command line: BOOT_IMAGE" then /var/log/votingworks/vx-logs.log;machineBootInit
+if $syslogtag == "systemd[1]:" and $msg contains "Startup finished" then /var/log/votingworks/vx-logs.log;machineBootSuccess
 
 ## Route logs for machine shutdown
 template(name="machineShutdownInit" type="list" option.jsonf="on") {
@@ -76,6 +76,6 @@ template(name="machineShutdownSuccess" type="list" option.jsonf="on") {
          property(outname="message" name="msg" format="jsonf")
  }
 
-if $programname == "systemd-logind" and ($msg contains "System is rebooting" or $msg contains "System is powering down") then /var/log/vx-logs.log;machineShutdownInit
-if $syslogtag == "systemd[1]:" and $msg contains "Shutting down" then /var/log/vx-logs.log;machineShutdownSuccess
+if $programname == "systemd-logind" and ($msg contains "System is rebooting" or $msg contains "System is powering down") then /var/log/votingworks/vx-logs.log;machineShutdownInit
+if $syslogtag == "systemd[1]:" and $msg contains "Shutting down" then /var/log/votingworks/vx-logs.log;machineShutdownSuccess
 

--- a/config/admin-functions/copy-logs.sh
+++ b/config/admin-functions/copy-logs.sh
@@ -28,9 +28,9 @@ DIRECTORY="$MOUNTPOINT/logs-$( date +%Y%m%d-%H%M%S )"
 mkdir -p "$DIRECTORY"
 
 # copy logs
-cp -r /var/log/syslog* "$DIRECTORY"
-cp -r /var/log/auth.log* "$DIRECTORY"
-cp -r /var/log/vx-logs.log* "$DIRECTORY"
+cp -r /var/log/votingworks/syslog* "$DIRECTORY"
+cp -r /var/log/votingworks/auth.log* "$DIRECTORY"
+cp -r /var/log/votingworks/vx-logs.log* "$DIRECTORY"
 
 # unmount the USB stick to make sure it's all written to disk
 echo "Saving logs to USB drive..."

--- a/config/rsyslog.conf
+++ b/config/rsyslog.conf
@@ -61,3 +61,21 @@ $WorkDirectory /var/spool/rsyslog
 # Include all config files in /etc/rsyslog.d/
 #
 $IncludeConfig /etc/rsyslog.d/*.conf
+
+###############
+#### RULES ####
+###############
+
+#
+# Log anything besides private authentication messages to a single log file
+#
+*.*;auth,authpriv.none		-/var/log/syslog
+
+#
+# Log commonly used facilities to their own log file
+#
+auth,authpriv.*			/var/log/auth.log
+cron.*				-/var/log/cron.log
+kern.*				-/var/log/kern.log
+mail.*				-/var/log/mail.log
+user.*				-/var/log/user.log

--- a/config/rsyslog.conf
+++ b/config/rsyslog.conf
@@ -69,13 +69,13 @@ $IncludeConfig /etc/rsyslog.d/*.conf
 #
 # Log anything besides private authentication messages to a single log file
 #
-*.*;auth,authpriv.none		-/var/log/syslog
+*.*;auth,authpriv.none		-/var/log/votingworks/syslog
 
 #
 # Log commonly used facilities to their own log file
 #
-auth,authpriv.*			/var/log/auth.log
-cron.*				-/var/log/cron.log
-kern.*				-/var/log/kern.log
-mail.*				-/var/log/mail.log
-user.*				-/var/log/user.log
+auth,authpriv.*			/var/log/votingworks/auth.log
+cron.*				-/var/log/votingworks/cron.log
+kern.*				-/var/log/votingworks/kern.log
+mail.*				-/var/log/votingworks/mail.log
+user.*				-/var/log/votingworks/user.log

--- a/config/sudoers
+++ b/config/sudoers
@@ -41,3 +41,4 @@ vx-ui ALL=(root:ALL) NOPASSWD: /vx/code/app-scripts/sign.sh
 vx-ui ALL=(root:ALL) NOPASSWD: /vx/code/app-scripts/mount-usb.sh
 vx-ui ALL=(root:ALL) NOPASSWD: /vx/code/app-scripts/unmount-usb.sh
 vx-ui ALL=(root:ALL) NOPASSWD: /bin/efibootmgr
+vx-ui ALL=(root:ALL) NOPASSWD: /sbin/logrotate

--- a/config/sudoers-for-dev
+++ b/config/sudoers-for-dev
@@ -42,3 +42,4 @@ vx-ui ALL=(root:ALL) NOPASSWD: /vx/code/app-scripts/sign.sh
 vx-ui ALL=(root:ALL) NOPASSWD: /vx/code/app-scripts/mount-usb.sh
 vx-ui ALL=(root:ALL) NOPASSWD: /vx/code/app-scripts/unmount-usb.sh
 vx-ui ALL=(root:ALL) NOPASSWD: /bin/efibootmgr
+vx-ui ALL=(root:ALL) NOPASSWD: /sbin/logrotate

--- a/run-scripts/run-kiosk-browser-forever-and-log.sh
+++ b/run-scripts/run-kiosk-browser-forever-and-log.sh
@@ -5,6 +5,9 @@ set -euo pipefail
 # go to directory where this file is located
 cd "$(dirname "$0")"
 
+# rotate vx-logs.log if necessary
+sudo /sbin/logrotate --force /etc/vx-logs.logrotate
+
 # configuration information
 CONFIG=${VX_CONFIG_ROOT:-./config}
 METADATA=${VX_METADATA_ROOT:-./}

--- a/run-scripts/run-kiosk-browser-forever-and-log.sh
+++ b/run-scripts/run-kiosk-browser-forever-and-log.sh
@@ -6,7 +6,9 @@ set -euo pipefail
 cd "$(dirname "$0")"
 
 # rotate vx-logs.log if necessary
-sudo /sbin/logrotate --force /etc/vx-logs.logrotate
+# always return true on failure since logs dont always need rotating
+# but logrotate throws an error code
+sudo /sbin/logrotate --force /etc/vx-logs.logrotate || true
 
 # configuration information
 CONFIG=${VX_CONFIG_ROOT:-./config}

--- a/setup-scripts/setup-logging.sh
+++ b/setup-scripts/setup-logging.sh
@@ -1,10 +1,3 @@
-# Check if syslog is a user. If not, add it
-if ! id syslog &> /dev/null; then
-	sudo useradd -U -G adm,tty syslog
-fi
-
-sudo chown syslog:adm /var/spool/rsyslog
-
 sudo cp config/30-votingworks.conf /etc/rsyslog.d/30-votingworks.conf
 sudo cp config/rsyslog.conf /etc/rsyslog.conf
 sudo cp config/journald.conf /etc/systemd/journald.conf

--- a/setup-scripts/setup-logging.sh
+++ b/setup-scripts/setup-logging.sh
@@ -7,16 +7,8 @@ if ! id syslog &> /dev/null; then
 	sudo chmod 775 /var/log
 fi
 
-ver="$(lsb_release -sr)"
-if [[ $ver == 18* ]] ;
-then
-  sudo add-apt-repository -y ppa:adiscon/v8-devel
-  sudo apt-get update
-  sudo apt-get install -y rsyslog
-fi
-
 sudo cp config/30-votingworks.conf /etc/rsyslog.d/30-votingworks.conf
 sudo cp config/rsyslog.conf /etc/rsyslog.conf
-sudo cp config/journald.conf /etc/systemd/journald.conf
+#sudo cp config/journald.conf /etc/systemd/journald.conf
 
 sudo systemctl restart rsyslog

--- a/setup-scripts/setup-logging.sh
+++ b/setup-scripts/setup-logging.sh
@@ -11,4 +11,11 @@ sudo cp config/30-votingworks.conf /etc/rsyslog.d/30-votingworks.conf
 sudo cp config/rsyslog.conf /etc/rsyslog.conf
 #sudo cp config/journald.conf /etc/systemd/journald.conf
 
+# Truncate existing log files so build operations are not
+# part of production use
+for file in mail.log kern.log auth.log user.log cron.log
+do
+  sudo sh -c "cat /dev/null > /var/log/${file}"
+done
+
 sudo systemctl restart rsyslog

--- a/setup-scripts/setup-logging.sh
+++ b/setup-scripts/setup-logging.sh
@@ -8,12 +8,12 @@ if ! id syslog &> /dev/null; then
 fi
 
 sudo cp config/30-votingworks.conf /etc/rsyslog.d/30-votingworks.conf
-sudo cp config/rsyslog.conf /etc/rsyslog.conf
-#sudo cp config/journald.conf /etc/systemd/journald.conf
+#sudo cp config/rsyslog.conf /etc/rsyslog.conf
+sudo cp config/journald.conf /etc/systemd/journald.conf
 
 # Truncate existing log files so build operations are not
 # part of production use
-for file in mail.log kern.log auth.log user.log cron.log
+for file in mail.log kern.log user.log cron.log syslog auth.log
 do
   sudo sh -c "cat /dev/null > /var/log/${file}"
 done

--- a/setup-scripts/setup-logging.sh
+++ b/setup-scripts/setup-logging.sh
@@ -1,22 +1,20 @@
 # Check if syslog is a user. If not, add it
 if ! id syslog &> /dev/null; then
 	sudo useradd -U -G adm,tty syslog
-	sudo chown syslog:adm /var/spool/rsyslog
-	sudo chown syslog:adm /var/log/syslog
-	sudo chown :adm /var/log
-	sudo chmod 775 /var/log
 fi
+
+sudo chown syslog:adm /var/spool/rsyslog
 
 sudo cp config/30-votingworks.conf /etc/rsyslog.d/30-votingworks.conf
 sudo cp config/rsyslog.conf /etc/rsyslog.conf
-#sudo cp config/journald.conf /etc/systemd/journald.conf
+sudo cp config/journald.conf /etc/systemd/journald.conf
 
 # Truncate existing log files so build operations are not
 # part of production use
 for file in mail.log kern.log user.log cron.log syslog auth.log
 do
-  sudo sh -c "cat /dev/null > /var/log/${file}"
-  sudo chown syslog:adm /var/log/${file}
+  sudo sh -c "cat /dev/null > /var/log/votingworks/${file}"
+  sudo chown syslog:adm /var/log/votingworks/${file}
 done
 
 sudo systemctl restart rsyslog

--- a/setup-scripts/setup-logging.sh
+++ b/setup-scripts/setup-logging.sh
@@ -8,14 +8,15 @@ if ! id syslog &> /dev/null; then
 fi
 
 sudo cp config/30-votingworks.conf /etc/rsyslog.d/30-votingworks.conf
-#sudo cp config/rsyslog.conf /etc/rsyslog.conf
-sudo cp config/journald.conf /etc/systemd/journald.conf
+sudo cp config/rsyslog.conf /etc/rsyslog.conf
+#sudo cp config/journald.conf /etc/systemd/journald.conf
 
 # Truncate existing log files so build operations are not
 # part of production use
 for file in mail.log kern.log user.log cron.log syslog auth.log
 do
   sudo sh -c "cat /dev/null > /var/log/${file}"
+  sudo chown syslog:adm /var/log/${file}
 done
 
 sudo systemctl restart rsyslog


### PR DESCRIPTION
This PR updates our logging configuration to meet VVSG2.0 requirements. Notably:

- System and application logs have been moved to the `/var/log/votingworks/` directory to address permissions issues.
- Log rotation configurations have been created for system and application logs.
- The `vx-logs.log` application log is rotated on startup rather than via a set schedule to prevent any potential data loss caused by the copytruncate operation.
- Logs are truncated during `setup-logging.sh` to minimize the amount of log entries created during the image build.