### PR TITLE
mirror to an external HDMI display for public viewing of admin/adjudication

### DIFF
--- a/config/xinitrc
+++ b/config/xinitrc
@@ -31,7 +31,20 @@ ELO="Elo Touch"
      # delay because it appears the xrandr and xinput commands above turn off sound for a bit
      # (because of course they do)
      sleep 5 && aplay ~/chime.wav
-fi) &
+ fi) &
+
+# look for an external display and mirror to it
+(while true; do
+     sleep 5
+
+     if xrandr | grep "HDMI-1 connected"; then
+	 xrandr --output HDMI-1 --mode 1920x1080 --same-as eDP-1 > /dev/null
+
+	 # once this is done, we don't need to loop anymore
+	 # the setting will survive unplug/replug until next reboot
+	 break
+     fi
+ done) &
 
 # brightness all the way
 sudo brightnessctl s 100%


### PR DESCRIPTION
Could have used fancy `udev` approach that @jdVotingWorks suggested, but to test that properly I need a production-imaged machine and need to figure out some more X11 magic. So I'm going with super duper simple for now, checked that `xrandr` execution is cheap, only doing it every 5s, and we only end up calling xrandr to change the display at most once per login session, so this is about as conservative and simple a change as I can come up with.

![image](https://github.com/votingworks/vxsuite-complete-system/assets/18057/e1854b05-3b19-4a3b-b6ab-26a417444635)

closes https://github.com/votingworks/vxsuite/issues/4038