### PR TITLE
Update cert dance to prompt users to select a USB drive

### DIFF
--- a/config/admin-functions/create-machine-cert.sh
+++ b/config/admin-functions/create-machine-cert.sh
@@ -5,6 +5,7 @@
 set -euo pipefail
 
 : "${VX_CONFIG_ROOT:="/vx/config"}"
+: "${VX_FUNCTIONS_ROOT:="$(dirname "${0}")"}"
 : "${VX_METADATA_ROOT:="/vx/code"}"
 : "${VX_MACHINE_TYPE:="$(< "${VX_CONFIG_ROOT}/machine-type")"}"
 
@@ -13,12 +14,8 @@ if [[ "${VX_MACHINE_TYPE}" == "admin" ]]; then
 else
     MACHINE_CERT_PATH="${VX_CONFIG_ROOT}/vx-${VX_MACHINE_TYPE}-cert.pem"
 fi
-USB_CERTS_DIRECTORY="/media/vx/usb-drive/certs"
+USB_DRIVE_CERTS_DIRECTORY="/media/vx/usb-drive/certs"
 VX_IANA_ENTERPRISE_OID="1.3.6.1.4.1.59817"
-
-# ---------- Helpers ----------
-
-# User input helpers
 
 function get_machine_jurisdiction_from_user_input() {
     local prompt="Enter a jurisdiction ({state-2-letter-abbreviation}.{county-or-town}, e.g. ms.warren or ca.los-angeles): "
@@ -35,65 +32,21 @@ function get_machine_jurisdiction_from_user_input() {
     echo "${machine_jurisdiction}"
 }
 
-# USB helpers
-
-# Returns the path to the first connected USB stick, if any. Returns an empty string if no USB
-# stick is connected.
-function get_usb_path() {
-    lsblk /dev/disk/by-id/usb*part* --noheadings --output PATH 2> /dev/null | grep / --max-count 1
-}
-
-# Errs if no USB is mounted (or if unmounting fails for some other reason)
-function unmount_usb() {
-    "${VX_METADATA_ROOT}/app-scripts/unmount-usb.sh"
-}
-
-# Never errs, even if no USB is mounted
-function unmount_usb_if_mounted() {
-    "${VX_METADATA_ROOT}/app-scripts/unmount-usb.sh" 2> /dev/null || true
-}
-
-function mount_usb() {
-    local usb_path="${1}"
-    unmount_usb_if_mounted
-    "${VX_METADATA_ROOT}/app-scripts/mount-usb.sh" "${usb_path}"
-}
-
-function mount_usb_if_present() {
-    local usb_path="$(get_usb_path)"
-    if [[ -n "${usb_path}" ]]; then
-        mount_usb "${usb_path}"
-    fi
-}
-
-function wait_for_usb_and_mount_once_present() {
-    while true; do
-        local usb_path="$(get_usb_path)"
-        if [[ -n "${usb_path}" ]]; then
-            mount_usb "${usb_path}"
-            break
-        fi
-        sleep 1
-    done
-}
-
-# OpenSSL helpers
-
 function create_machine_cert_signing_request() {
-    pushd "${VX_METADATA_ROOT}/vxsuite/libs/auth" > /dev/null
     local machine_jurisdiction="${1:-}"
     if [[ -n "${machine_jurisdiction}" ]]; then
         VX_MACHINE_TYPE="${VX_MACHINE_TYPE}" \
         VX_MACHINE_JURISDICTION="${machine_jurisdiction}" \
-        ./scripts/create-production-machine-cert-signing-request
+        "${VX_METADATA_ROOT}/vxsuite/libs/auth/scripts/create-production-machine-cert-signing-request"
     else
         VX_MACHINE_TYPE="${VX_MACHINE_TYPE}" \
-        ./scripts/create-production-machine-cert-signing-request
+        "${VX_METADATA_ROOT}/vxsuite/libs/auth/scripts/create-production-machine-cert-signing-request"
     fi
-    popd > /dev/null
 }
 
-# Permissions helpers
+function unmount_usb_drive() {
+    "${VX_METADATA_ROOT}/app-scripts/unmount-usb.sh"
+}
 
 # Applies permissions to match the permissions of other non-executable files in VX_CONFIG_ROOT
 function match_vx_config_non_executable_file_permissions() {
@@ -102,46 +55,41 @@ function match_vx_config_non_executable_file_permissions() {
     chmod u=rw,g=r,o= "${file_path}"
 }
 
-# ---------- Script ----------
-
 mkdir -p "${VX_CONFIG_ROOT}"
 
 if [[ ${VX_MACHINE_TYPE} == "admin" ]]; then
     machine_jurisdiction="$(get_machine_jurisdiction_from_user_input)"
 fi
 
-echo "Insert a USB into the machine. The USB will be auto-detected."
-sleep 1
-wait_for_usb_and_mount_once_present
-echo "USB detected!"
+read -p "Insert a USB drive into the machine. Press enter once you've done so. "
+"${VX_FUNCTIONS_ROOT}/select-usb-drive-and-mount.sh"
 
-echo "Writing cert signing request to USB..."
-rm -rf "${USB_CERTS_DIRECTORY}"
-mkdir "${USB_CERTS_DIRECTORY}"
+echo "Writing cert signing request to USB drive..."
+rm -rf "${USB_DRIVE_CERTS_DIRECTORY}"
+mkdir "${USB_DRIVE_CERTS_DIRECTORY}"
 if [[ ${VX_MACHINE_TYPE} == "admin" ]]; then
-    create_machine_cert_signing_request "${machine_jurisdiction}" > "${USB_CERTS_DIRECTORY}/csr.pem"
+    create_machine_cert_signing_request "${machine_jurisdiction}" > "${USB_DRIVE_CERTS_DIRECTORY}/csr.pem"
 else
-    create_machine_cert_signing_request > "${USB_CERTS_DIRECTORY}/csr.pem"
+    create_machine_cert_signing_request > "${USB_DRIVE_CERTS_DIRECTORY}/csr.pem"
 fi
-echo "${VX_MACHINE_TYPE}" > "${USB_CERTS_DIRECTORY}/machine-type"
-unmount_usb
+echo "${VX_MACHINE_TYPE}" > "${USB_DRIVE_CERTS_DIRECTORY}/machine-type"
+unmount_usb_drive
 
-read -p "Remove the USB, take it to VxCertifier, and bring it back to this machine when prompted. Press enter once you've re-inserted the USB. "
+read -p "Remove the USB drive, take it to VxCertifier, and bring it back to this machine when prompted. Press enter once you've re-inserted the USB drive. "
 
 while true; do
-    mount_usb_if_present
-    if [[ -f "${USB_CERTS_DIRECTORY}/cert.pem" ]]; then
+    "${VX_FUNCTIONS_ROOT}/select-usb-drive-and-mount.sh"
+    if [[ -f "${USB_DRIVE_CERTS_DIRECTORY}/cert.pem" ]]; then
         break
     fi
-    unmount_usb_if_mounted
-    read -p "Cert not found on USB. Double check that you've inserted the right USB and given it time to mount. Press enter to try again. "
+    read -p "Cert not found on USB drive. Double check that you've inserted the right USB drive and given it time to mount. Press enter to try again. "
 done
-echo "Cert found on USB!"
+echo "Cert found on USB drive!"
 
 echo "Copying cert to ${MACHINE_CERT_PATH}..."
-cp "${USB_CERTS_DIRECTORY}/cert.pem" "${MACHINE_CERT_PATH}"
+cp "${USB_DRIVE_CERTS_DIRECTORY}/cert.pem" "${MACHINE_CERT_PATH}"
 match_vx_config_non_executable_file_permissions "${MACHINE_CERT_PATH}"
-rm -rf "${USB_CERTS_DIRECTORY}"
-unmount_usb
+rm -rf "${USB_DRIVE_CERTS_DIRECTORY}"
+unmount_usb_drive
 
-echo "Machine cert saved! You can remove the USB."
+echo "Machine cert saved! You can remove the USB drive."

--- a/config/admin-functions/program-system-administrator-cards.sh
+++ b/config/admin-functions/program-system-administrator-cards.sh
@@ -10,13 +10,11 @@ set -euo pipefail
 : "${VX_MACHINE_TYPE:="$(< "${VX_CONFIG_ROOT}/machine-type")"}"
 
 function program_system_administrator_card() {
-    pushd "${VX_METADATA_ROOT}/vxsuite/libs/auth" > /dev/null
     NODE_ENV=production \
     VX_CONFIG_ROOT="${VX_CONFIG_ROOT}" \
     VX_MACHINE_JURISDICTION="${VX_MACHINE_JURISDICTION}" \
     VX_MACHINE_TYPE="${VX_MACHINE_TYPE}" \
-    ./scripts/program-system-administrator-java-card
-    popd > /dev/null
+    "${VX_METADATA_ROOT}/vxsuite/libs/auth/scripts/program-system-administrator-java-card"
 }
 
 # Close any existing connections to the card reader, e.g. from the VxAdmin app

--- a/config/admin-functions/select-usb-drive-and-mount.sh
+++ b/config/admin-functions/select-usb-drive-and-mount.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Requires sudo
+
+set -euo pipefail
+
+: "${VX_METADATA_ROOT:="/vx/code"}"
+
+function get_usb_drives_json() {
+    (lsblk /dev/disk/by-id/usb*part* -o LABEL,NAME,SIZE,PATH --json 2> /dev/null || true) | jq ".blockdevices"
+}
+
+while true; do
+    usb_drives_json="$(get_usb_drives_json)"
+    if [[ "${usb_drives_json}" == "[]" ]]; then
+        read -p "No USB drives found. Press enter to try again. "
+    else
+        # Pretty print the detected USB drives, prefixed with numeric indexes
+        readarray -t usb_drives <<< "$(jq -r ".[] | [.label, .name, .path, .size] | @tsv" <<< "${usb_drives_json}")"
+        echo
+        echo "USB drive(s) detected:"
+        for i in "${!usb_drives[@]}"; do
+            echo "${i}. ${usb_drives[i]}"
+        done
+        echo
+
+        while true; do
+            read -p "Enter the index (0, 1, etc.) of the USB drive that you'd like to use, or press enter to search for USB drives again: " index
+            if [[ -z "${index}" ]]; then
+                # Search for USB drives again
+                break 1
+            elif ! [[ "${index}" =~ ^[0-9]+$ ]]; then
+                echo -e "\e[31mInvalid index\e[0m" >&2
+            else
+                selected_usb_drive_device_path="$(jq -r ".[${index}].path" <<< "${usb_drives_json}")"
+                if [[ "${selected_usb_drive_device_path}" == "null" ]]; then
+                    echo -e "\e[31mInvalid index\e[0m" >&2
+                else
+                    # USB drive selected
+                    break 2
+                fi
+            fi
+        done
+    fi
+done
+
+# Unmount USB drive if already mounted then mount selected USB drive
+"${VX_METADATA_ROOT}/app-scripts/unmount-usb.sh" 2> /dev/null || true
+"${VX_METADATA_ROOT}/app-scripts/mount-usb.sh" "${selected_usb_drive_device_path}"


### PR DESCRIPTION
_Easiest reviewed by commit_

## Overview

<img src='https://github.com/votingworks/vxsuite-complete-system/assets/12616928/b250b19a-10ff-4376-8604-addaee5cd815' alt='dancing-usb-drive' width=200 />

The VxCertifier cert dance currently assumes that only one USB drive is connected to the machine. This assumption has both caused confusion and, even when we're aware of it, been a limitation.

For example, we often leave the USB drive(s) used for imaging connected to the machine during cert creation. During the cert dance, it's unclear which of the connected USB drives gets written to.

We've also been wanting to image external hard drives that we can then boot from for testing. Completing the cert dance for these drives is tricky with the current one-drive assumption.

This PR updates the cert dance to prompt users to select a USB drive at all relevant steps. I've updated not only the create-machine-cert script but also the mock-vx-certifier script, where the one-drive assumption has also been a nuisance.

## Demo

_create-machine-cert.sh_

```
$ sudo VX_MACHINE_TYPE=admin VX_METADATA_ROOT=. ./config/admin-functions/create-machine-cert.sh
Enter a jurisdiction ({state-2-letter-abbreviation}.{county-or-town}, e.g. ms.warren or ca.los-angeles): nh.sli-testing
Insert a USB drive into the machine. Press enter once you've done so. 
No USB drives found. Press enter to try again. 

USB drive(s) detected:
0. VxUSB-5WDO8	sdb1	/dev/sdb1	28.9G

Enter the index (0, 1, etc.) of the USB drive that you'd like to use, or press enter to search for USB drives again: 

USB drive(s) detected:
0. VxUSB-5WDO8	sdb1	/dev/sdb1	28.9G
1. VxUSB-J7S2W	sdc1	/dev/sdc1	28.9G

Enter the index (0, 1, etc.) of the USB drive that you'd like to use, or press enter to search for USB drives again: 2
Invalid index
Enter the index (0, 1, etc.) of the USB drive that you'd like to use, or press enter to search for USB drives again: a
Invalid index
Enter the index (0, 1, etc.) of the USB drive that you'd like to use, or press enter to search for USB drives again: 0
Writing cert signing request to USB drive...
Remove the USB drive, take it to VxCertifier, and bring it back to this machine when prompted. Press enter once you've re-inserted the USB drive. 

USB drive(s) detected:
0. VxUSB-5WDO8	sdb1	/dev/sdb1	28.9G
1. VxUSB-J7S2W	sdc1	/dev/sdc1	28.9G

Enter the index (0, 1, etc.) of the USB drive that you'd like to use, or press enter to search for USB drives again: 1
Cert not found on USB drive. Double check that you've inserted the right USB drive and given it time to mount. Press enter to try again. 

USB drive(s) detected:
0. VxUSB-5WDO8	sdb1	/dev/sdb1	28.9G
1. VxUSB-J7S2W	sdc1	/dev/sdc1	28.9G

Enter the index (0, 1, etc.) of the USB drive that you'd like to use, or press enter to search for USB drives again: 0
Cert found on USB drive!
Copying cert to /vx/config/vx-admin-cert-authority-cert.pem...
Machine cert saved! You can remove the USB drive.
```

_mock-vx-certifier.sh_

```
$ sudo VX_PRIVATE_KEY_PATH=/path/to/vx-private-key.pem ./config/admin-functions/mock-vx-certifier.sh

USB drive(s) detected:
0. VxUSB-5WDO8	sdb1	/dev/sdb1	28.9G
1. VxUSB-J7S2W	sdc1	/dev/sdc1	28.9G

Enter the index (0, 1, etc.) of the USB drive that you'd like to use, or press enter to search for USB drives again: 0
Certificate request self-signature ok
subject=C = US, ST = CA, O = VotingWorks, 1.3.6.1.4.1.59817.1 = admin, 1.3.6.1.4.1.59817.2 = nh.sli-testing
```

## Testing

- [x] Tested manually on my Debian 12 VM
- [x] Tested manually on my Debian 12 ThinkPad