### PR TITLE
Call vxsuite scripts from within vxsuite

### DIFF
--- a/config/admin-functions/create-machine-cert.sh
+++ b/config/admin-functions/create-machine-cert.sh
@@ -33,15 +33,17 @@ function get_machine_jurisdiction_from_user_input() {
 }
 
 function create_machine_cert_signing_request() {
+    pushd "${VX_METADATA_ROOT}/vxsuite/libs/auth/scripts" > /dev/null
     local machine_jurisdiction="${1:-}"
     if [[ -n "${machine_jurisdiction}" ]]; then
         VX_MACHINE_TYPE="${VX_MACHINE_TYPE}" \
-        VX_MACHINE_JURISDICTION="${machine_jurisdiction}" \
-        "${VX_METADATA_ROOT}/vxsuite/libs/auth/scripts/create-production-machine-cert-signing-request"
+            VX_MACHINE_JURISDICTION="${machine_jurisdiction}" \
+            ./create-production-machine-cert-signing-request
     else
         VX_MACHINE_TYPE="${VX_MACHINE_TYPE}" \
-        "${VX_METADATA_ROOT}/vxsuite/libs/auth/scripts/create-production-machine-cert-signing-request"
+            ./create-production-machine-cert-signing-request
     fi
+    popd > /dev/null
 }
 
 function unmount_usb_drive() {

--- a/config/admin-functions/program-system-administrator-cards.sh
+++ b/config/admin-functions/program-system-administrator-cards.sh
@@ -10,11 +10,14 @@ set -euo pipefail
 : "${VX_MACHINE_TYPE:="$(< "${VX_CONFIG_ROOT}/machine-type")"}"
 
 function program_system_administrator_card() {
+    # The underlying vxsuite script must be called from within vxsuite
+    pushd "${VX_METADATA_ROOT}/vxsuite/libs/auth/scripts" > /dev/null
     NODE_ENV=production \
-    VX_CONFIG_ROOT="${VX_CONFIG_ROOT}" \
-    VX_MACHINE_JURISDICTION="${VX_MACHINE_JURISDICTION}" \
-    VX_MACHINE_TYPE="${VX_MACHINE_TYPE}" \
-    "${VX_METADATA_ROOT}/vxsuite/libs/auth/scripts/program-system-administrator-java-card"
+        VX_CONFIG_ROOT="${VX_CONFIG_ROOT}" \
+        VX_MACHINE_JURISDICTION="${VX_MACHINE_JURISDICTION}" \
+        VX_MACHINE_TYPE="${VX_MACHINE_TYPE}" \
+        ./program-system-administrator-java-card
+    popd > /dev/null
 }
 
 # Close any existing connections to the card reader, e.g. from the VxAdmin app


### PR DESCRIPTION
## Overview

Smart card programming in the machine configuration wizard is yielding the following error message:

```
/home/vx/code/vxsuite/libs/auth/scripts/vxsuite/node_modules/.pnpm/bindings@1.5.0/node_modules/bindings/bindings.js:211
      throw new Error(
            ^
Error: Could not find module root given file: "node:internal/modules/cjs/loader". Do you have a `package.json` file? 
    at Function.getRoot (/home/vx/code/vxsuite/libs/auth/scripts/vxsuite/node_modules/.pnpm/bindings@1.5.0/node_modules/bindings/bindings.js:211:13)
    at bindings (/home/vx/code/vxsuite/libs/auth/scripts/vxsuite/node_modules/.pnpm/bindings@1.5.0/node_modules/bindings/bindings.js:82:32)
    at vxsuite/node_modules/.pnpm/pcsclite@1.0.1/node_modules/pcsclite/lib/pcsclite.js (/home/vx/code/vxsuite/libs/auth/scripts/vxsuite/node_modules/.pnpm/pcsclite@1.0.1/node_modules/pcsclite/lib/pcsclite.js:4:16)
    at __require (/home/vx/code/vxsuite/libs/auth/scripts/program_system_administrator_java_card.ts:8:51)
    at vxsuite/node_modules/.pnpm/pcsclite@1.0.1/node_modules/pcsclite/index.js (/home/vx/code/vxsuite/libs/auth/scripts/vxsuite/node_modules/.pnpm/pcsclite@1.0.1/node_modules/pcsclite/index.js:1:18)
    at __require (/home/vx/code/vxsuite/libs/auth/scripts/program_system_administrator_java_card.ts:8:51)
    at Object.<anonymous> (/home/vx/code/vxsuite/libs/auth/scripts/vxsuite/libs/auth/src/card_reader.ts:2:25)
    at Module._compile (node:internal/modules/cjs/loader:1191:14)
    at Module._compile (/home/vx/code/vxsuite/node_modules/.pnpm/source-map-support@0.5.21/node_modules/source-map-support/source-map-support.js:568:25)
    at Module.mod._compile (/home/vx/code/vxsuite/node_modules/.pnpm/esbuild-runner@2.2.2_esbuild@0.17.11/node_modules/esbuild-runner/src/hook.ts:53:22)
```

This recent [commit](https://github.com/votingworks/vxsuite-complete-system/pull/349/commits/1b6d98c9eb993e63a96ab96eabcba30a28f10a45) is the problem. Looks like vxsuite's `program-system-administrator-java-card` script can be called from anywhere within vxsuite but not outside it. Interestingly, this same issue does not apply to vxsuite's `create-production-machine-cert-signing-request` script, which can be called from outside vxsuite, as is done [here](https://github.com/votingworks/vxsuite-complete-system/blob/fb3b404079bf9730fed1cb1935ba9e31dba6599b/config/admin-functions/create-machine-cert.sh#L43).

Regardless, I've updated vxsuite-complete-system to consistently cd into vxsuite before calling vxsuite scripts, as it used to.

## Testing

- [x] Tested modified vxsuite-complete-system scripts manually