### PR TITLE
fix flicker on raptor lake cards

### DIFF
--- a/config/grub
+++ b/config/grub
@@ -9,7 +9,7 @@ GRUB_TIMEOUT=0
 GRUB_HIDDEN_TIMEOUT=0
 GRUB_HIDDEN_TIMEOUT_QUIET=true
 GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
-GRUB_CMDLINE_LINUX_DEFAULT="quiet"
+GRUB_CMDLINE_LINUX_DEFAULT="quiet i915.enable_guc=2"
 GRUB_CMDLINE_LINUX=""
 
 # Uncomment to enable BadRAM filtering, modify to suit your needs

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -131,6 +131,8 @@ sudo usermod -aG vx-group vx-ui
 sudo usermod -aG vx-group vx-admin
 sudo usermod -aG vx-group vx-services
 
+sudo usermod -aG video vx-ui
+
 # remove all files created by default
 sudo rm -rf /vx/services/* /vx/ui/* /vx/admin/*
 


### PR DESCRIPTION
Under X, modesetting isn't able to load correctly due to firmware not being loaded properly. That results in initial screen flickering when kiosk-browser starts/restarts. This setting corrects that and does not interfere on systems with a different intel card. 