### PR TITLE
Change approach to kernel module options and potential signing requirements

### DIFF
--- a/config/admin-functions/lockdown.sh
+++ b/config/admin-functions/lockdown.sh
@@ -26,7 +26,12 @@ if [[ $answer == 'n' || $answer == 'N' ]]; then
     exit
 fi
 
-modules_to_sign="i915"
+# We don't need to sign i915 since it is signed by Debian's Secure Boot key
+# and we have access to that under Secure Boot. 
+# However, if we do ever need to use an unsigned module, the below code 
+# will sign with the VotingWorks key.
+# You would just add modules to the var, e.g. modules_to_sign="i915 mod2 mod3"
+modules_to_sign=""
 if [[ $surface == 0 ]] && [[ -n $modules_to_sign ]]; then
   read -s -p "Please enter the passphrase for the secure boot key: " KBUILD_SIGN_PIN
 

--- a/config/admin-functions/lockdown.sh
+++ b/config/admin-functions/lockdown.sh
@@ -26,6 +26,17 @@ if [[ $answer == 'n' || $answer == 'N' ]]; then
     exit
 fi
 
+if [ $surface == 0 ]; then
+  read -s -p "Please enter the passphrase for the secure boot key: " KBUILD_SIGN_PIN
+
+  export KBUILD_SIGN_PIN
+
+  umount /dev/sda || true
+  umount /dev/sda1 || true
+  mount /dev/sda /mnt || mount /dev/sda1 /mnt || (echo "Secure boot keys not found; exiting" && sleep 5 && exit);
+
+  /usr/src/linux-kbuild-6.1/scripts/sign-file sha256 /mnt/DB.key /mnt/DB.crt $(modinfo -n i915)
+fi
 
 update-initramfs -u
 

--- a/config/grub
+++ b/config/grub
@@ -9,7 +9,7 @@ GRUB_TIMEOUT=0
 GRUB_HIDDEN_TIMEOUT=0
 GRUB_HIDDEN_TIMEOUT_QUIET=true
 GRUB_DISTRIBUTOR=`lsb_release -i -s 2> /dev/null || echo Debian`
-GRUB_CMDLINE_LINUX_DEFAULT="quiet i915.enable_guc=2"
+GRUB_CMDLINE_LINUX_DEFAULT="quiet"
 GRUB_CMDLINE_LINUX=""
 
 # Uncomment to enable BadRAM filtering, modify to suit your needs

--- a/config/modprobe.d/10-i915.conf
+++ b/config/modprobe.d/10-i915.conf
@@ -1,0 +1,1 @@
+options i915 enable_guc=2

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -169,6 +169,8 @@ sudo cp config/cups.service /usr/lib/systemd/system/
 sudo cp config/apparmor.d/usr.sbin.cupsd /etc/apparmor.d/
 sudo cp config/apparmor.d/usr.sbin.cups-browsed /etc/apparmor.d/
 
+# copy any modprobe configs we might use
+sudo cp config/modprobe.d/* /etc/modprobe.d/
 
 # let vx-services scan
 if [ "${CHOICE}" != "mark" ]


### PR DESCRIPTION
To eliminate screen flicker on the Raptor Lake card, we need to set `i915.enable_guc=2` to ensure all firmware loads. Prior to secure boot, we passed the option via the grub cmdline. The initial secure boot build brought back the screen flicker. Rather than also adding `i915.enable_guc=2` to the secure boot boot entry (feels very fragile, easy to forget on future module options, have to edit in two places, etc...), switched to using modprobe to configure any necessary options. This will be easier to maintain and understand. Since we're using modprobe, the option was removed from the non-secure boot grub config. 

During the troubleshooting phase, we also thought we might need to sign the `i915` module. That turned out to be a red herring since it's already secure boot signed via the Debian key. I've left in code to sign kernel modules in the future though, in case we ever end up needing one that is unsigned. 

If we find ourselves having to sign modules frequently, it will likely be worth a small refactor so module names are not hardcoded in the lockdown script, but this is sufficient for now. 