### PR TITLE
disable kiosk printing for all apps but mark

### DIFF
--- a/run-scripts/run-kiosk-browser.sh
+++ b/run-scripts/run-kiosk-browser.sh
@@ -3,16 +3,24 @@
 set -euo pipefail
 
 URL=${1:-http://localhost:3000}
-: "${VX_CONFIG_ROOT:="./config"}"
-: "${VX_METADATA_ROOT:="./"}"
-
-OS=$(lsb_release -cs)
 PRINTER_FILE='./printing/debian-printer-autoconfigure.json'
 
-kiosk-browser \
-  --add-file-perm o=http://localhost:3000,p=/media/**/*,rw \
-  --add-file-perm o=http://localhost:3000,p=/var/log,ro \
-  --add-file-perm o=http://localhost:3000,p=/var/log/*,ro \
-  --autoconfigure-print-config ${PRINTER_FILE} \
-  --url ${URL} || true
-
+case "${VX_MACHINE_TYPE:-}" in
+  scan|admin|central-scan)
+    # for these apps, kiosk browser does not need to or should not configure printers
+    kiosk-browser \
+      --add-file-perm o=http://localhost:3000,p=/media/**/*,rw \
+      --add-file-perm o=http://localhost:3000,p=/var/log,ro \
+      --add-file-perm o=http://localhost:3000,p=/var/log/*,ro \
+      --url ${URL} || true
+    ;;
+  *)
+    # by default, for mark and development, kiosk browser handles configuring printers
+    kiosk-browser \
+      --add-file-perm o=http://localhost:3000,p=/media/**/*,rw \
+      --add-file-perm o=http://localhost:3000,p=/var/log,ro \
+      --add-file-perm o=http://localhost:3000,p=/var/log/*,ro \
+      --autoconfigure-print-config ${PRINTER_FILE} \
+      --url ${URL} || true
+    ;;
+esac


### PR DESCRIPTION
it will default to on for development. I haven't seen any issues with it in dev while the backend service is also managing printing, but wouldn't risk it in prod