### PR TITLE
Add mark scan setup machine

### DIFF
--- a/config/admin-functions/mock-vx-certifier.sh
+++ b/config/admin-functions/mock-vx-certifier.sh
@@ -20,6 +20,7 @@ if [[
     "${VX_MACHINE_TYPE}" != "admin" &&
     "${VX_MACHINE_TYPE}" != "central-scan" &&
     "${VX_MACHINE_TYPE}" != "mark" &&
+    "${VX_MACHINE_TYPE}" != "mark-scan" &&
     "${VX_MACHINE_TYPE}" != "scan"
 ]]; then
     echo "VX_MACHINE_TYPE must be one of admin, central-scan, mark, or scan" >&2

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -31,6 +31,10 @@ echo "${#CHOICES[@]}. VxMark"
 CHOICES+=('mark')
 MODEL_NAMES+=('VxMark')
 
+echo "${#CHOICES[@]}. VxMarkScan"
+CHOICES+=('mark-scan')
+MODEL_NAMES+=('VxMarkScan')
+
 echo "${#CHOICES[@]}. VxScan"
 CHOICES+=('scan')
 MODEL_NAMES+=('VxScan')


### PR DESCRIPTION
Adds the bare minimum to allow us to make MarkScan images with setup-machine and then go through the certifier dance for them. I imagine there will be other things we need to add to the setup machine script for setting up the accessible controller and such 