### PR TITLE
Add support for mark-scan daemons to the trusted build process

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -118,6 +118,15 @@ fi
 
 for app in "${APPS_TO_BUILD[@]}"; do
   build "${app}"
+  # mark-scan has additional daemons that need to be built
+  # crates were fetched while online, now we build the release while offline
+  if [[ "${app}" == "mark-scan" ]]; then
+    for vx_daemon in accessible-controller pat-device-input
+    do
+      cd "${DIR}/vxsuite/apps/mark-scan/${vx_daemon}"
+      mkdir -p target && cargo build --offline --release --target-dir target/.
+    done
+  fi
 done
 
 exit 0

--- a/config/50-gpio.rules
+++ b/config/50-gpio.rules
@@ -1,0 +1,2 @@
+SUBSYSTEM=="gpio", ACTION=="add", PROGRAM="/bin/sh -c 'chown -R root:gpio /sys/class/gpio && chmod -R g+rw /sys/class/gpio'"
+SUBSYSTEM=="gpio", KERNEL=="gpio*", ACTION=="add", PROGRAM="/bin/sh -c 'chown -R root:gpio /sys/devices/platform/INT33FF:00/gpiochip0/gpio/* && chmod -R g+rw /sys/devices/platform/INT33FF:00/gpiochip0/gpio/*'"

--- a/config/50-uinput.rules
+++ b/config/50-uinput.rules
@@ -1,0 +1,1 @@
+KERNEL=="uinput", MODE="0660", GROUP="uinput"

--- a/config/uinput.conf
+++ b/config/uinput.conf
@@ -1,1 +1,0 @@
-uinput.conf

--- a/config/uinput.conf
+++ b/config/uinput.conf
@@ -1,0 +1,1 @@
+uinput.conf

--- a/config/xinitrc
+++ b/config/xinitrc
@@ -24,8 +24,8 @@ PENMOUNT="PENMOUNT PM2501"
      pactl unload-module module-suspend-on-idle
 
      # we are using landscape now, the following is for portrait
-     # xrandr -o left
-     # xinput set-prop "$PENMOUNT" 'Coordinate Transformation Matrix' 0 -1 1 1 0 0 0 0 1
+     xrandr -o left
+     xinput set-prop "$PENMOUNT" 'Coordinate Transformation Matrix' 0 -1 1 1 0 0 0 0 1
 
      # we need a startup chime to activate the channel
      # delay because it appears the xrandr and xinput commands above turn off sound for a bit

--- a/config/xinitrc
+++ b/config/xinitrc
@@ -12,6 +12,7 @@ export VX_METADATA_ROOT="/vx/code"
 
 # Penmount screen for mark-scan, adjust orientation and corresponding touch coordinates
 # xinput is not ready to be used until X has fully started, so we have to delay
+ELO="Elo Touch"
 PENMOUNT="PENMOUNT PM2501"
 (sleep 4 && if xinput list | grep -i "$PENMOUNT" > /dev/null; then
      # this is very specific to using the Lenovo m70q tiny with sound out via HDMI
@@ -23,9 +24,14 @@ PENMOUNT="PENMOUNT PM2501"
      # prevent suspending the module, otherwise the start of chimes gets clipped
      pactl unload-module module-suspend-on-idle
 
-     # we are using landscape now, the following is for portrait
+     # Rotate mark-scan screen to portrait
      xrandr -o left
      xinput set-prop "$PENMOUNT" 'Coordinate Transformation Matrix' 0 -1 1 1 0 0 0 0 1
+
+     # Uncomment to rotate Elo screen to portrait. You will also need to add $ELO to
+     # the `xinput list | grep` command
+     # xrandr -o right
+     # xinput set-prop "$ELO" 'Coordinate Transformation Matrix' 0 1 0 -1 0 1 0 0 1
 
      # we need a startup chime to activate the channel
      # delay because it appears the xrandr and xinput commands above turn off sound for a bit

--- a/config/xinitrc
+++ b/config/xinitrc
@@ -10,10 +10,10 @@ export VX_METADATA_ROOT="/vx/code"
 # this appears to fix the issue where, sometimes, the Elo touchscreen doesn't respond
 (sleep 6 && bash /vx/code/run-kiosk-browser-forever-and-log.sh) &
 
-# Elo screen, adjust orientation and corresponding touch coordinates
+# Penmount screen for mark-scan, adjust orientation and corresponding touch coordinates
 # xinput is not ready to be used until X has fully started, so we have to delay
-ELO="Elo Touch"
-(sleep 4 && if xinput list | grep -i "$ELO" > /dev/null; then
+PENMOUNT="PENMOUNT PM2501"
+(sleep 4 && if xinput list | grep -i "$PENMOUNT" > /dev/null; then
      # this is very specific to using the Lenovo m70q tiny with sound out via HDMI
      # pulseaudio --start
      # pulseaudio --kill
@@ -24,8 +24,8 @@ ELO="Elo Touch"
      pactl unload-module module-suspend-on-idle
 
      # we are using landscape now, the following is for portrait
-     # xrandr -o right
-     # xinput set-prop "$ELO" 'Coordinate Transformation Matrix' 0 1 0 -1 0 1 0 0 1
+     # xrandr -o left
+     # xinput set-prop "$PENMOUNT" 'Coordinate Transformation Matrix' 0 -1 1 1 0 0 0 0 1
 
      # we need a startup chime to activate the channel
      # delay because it appears the xrandr and xinput commands above turn off sound for a bit

--- a/prepare_build.sh
+++ b/prepare_build.sh
@@ -105,6 +105,10 @@ echo "Preparing ${#APPS_TO_BUILD[@]} app(s): ${APPS_TO_BUILD[@]}"
 
 for app in "${APPS_TO_BUILD[@]}"; do
   build "${app}"
+  if [[ "${app}" == "mark-scan" ]]; then
+    make -C "${DIR}/vxsuite/apps/mark-scan/accessible-controller" build
+    make -C "${DIR}/vxsuite/apps/mark-scan/pat-device-input" build
+  fi
 done
 
 exit 0

--- a/prepare_build.sh
+++ b/prepare_build.sh
@@ -98,8 +98,11 @@ build() {
 echo "Download all Rust crates"
 pnpm --recursive install:rust-addon
 
-echo "Download all kiosk-browser tools"
-make -C kiosk-browser install
+if ! which kiosk-browser >/dev/null 2>&1
+then
+  echo "Download all kiosk-browser tools"
+  make -C kiosk-browser install
+fi
 
 echo "Preparing ${#APPS_TO_BUILD[@]} app(s): ${APPS_TO_BUILD[@]}"
 

--- a/prepare_build.sh
+++ b/prepare_build.sh
@@ -105,9 +105,14 @@ echo "Preparing ${#APPS_TO_BUILD[@]} app(s): ${APPS_TO_BUILD[@]}"
 
 for app in "${APPS_TO_BUILD[@]}"; do
   build "${app}"
+  # mark-scan has additional daemons that need to be built
+  # so we fetch their Rust crates while online
   if [[ "${app}" == "mark-scan" ]]; then
-    make -C "${DIR}/vxsuite/apps/mark-scan/accessible-controller" build
-    make -C "${DIR}/vxsuite/apps/mark-scan/pat-device-input" build
+    for vx_daemon in accessible-controller pat-device-input
+    do
+      cd "${DIR}/vxsuite/apps/mark-scan/${vx_daemon}"
+      cargo fetch
+    done
   fi
 done
 

--- a/run.sh
+++ b/run.sh
@@ -49,6 +49,15 @@ if [[ " ${ALL_APPS[@]} " =~ " ${APP} " ]]; then
   [ -f "${VX_METADATA_ROOT}/code-version" ] || echo dev > "${VX_METADATA_ROOT}/code-version" 
   [ -f "${VX_METADATA_ROOT}/code-tag" ] || echo dev > "${VX_METADATA_ROOT}/code-tag" 
 
+  # mark-scan requires daemons running in the background
+  # reload their daemon configs and then issue restart commands
+  if [[ "${APP}" == "mark-scan" ]]; then
+    sudo systemctl daemon-reload
+    for vx_daemon in controller pat
+    do
+      sudo systemctl restart mark-scan-${vx_daemon}-daemon.service
+    done
+  fi
   export DISPLAY=${DISPLAY:-:0}
   cd "${DIR}/build/${APP}"
   (

--- a/run.sh
+++ b/run.sh
@@ -36,6 +36,7 @@ APP="$1"
 if [[ " ${ALL_APPS[@]} " =~ " ${APP} " ]]; then
   if [ ! -d "${DIR}/build/${APP}" ]; then
     echo "⁉️ ${APP} is not yet built, building…"
+    "${DIR}/prepare_build.sh" "${APP}"
     "${DIR}/build.sh" "${APP}"
   fi
 

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -195,6 +195,10 @@ fi
 
 if [ "${CHOICE}" == "mark-scan" ]
 then
+    # create groups if they don't already exist
+    sudo getent group uinput || sudo groupadd uinput
+    sudo getent group gpio || sudo groupadd gpio
+
     # let vx-services use virtual uinput devices
     sudo cp config/50-uinput.rules /etc/udev/rules.d/
     sudo usermod -aG uinput vx-services

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -200,6 +200,7 @@ sudo cp -rp vxsuite /vx/code/
 sudo ln -s /vx/code/vxsuite /vx/services/vxsuite
 sudo ln -s /vx/code/run-${CHOICE}.sh /vx/services/run-${CHOICE}.sh
 
+
 # symlink appropriate vx/ui files
 sudo ln -s /vx/code/config/ui_bash_profile /vx/ui/.bash_profile
 sudo ln -s /vx/code/config/Xresources /vx/ui/.Xresources
@@ -325,6 +326,18 @@ sudo cp config/${CHOICE}.service /etc/systemd/system/
 sudo chmod 644 /etc/systemd/system/${CHOICE}.service
 sudo systemctl enable ${CHOICE}.service
 sudo systemctl start ${CHOICE}.service
+
+# mark-scan requires additional service daemons
+if [[ "${CHOICE}" == "mark-scan" ]]; then
+  for vx_daemon in controller pat
+  do
+    sudo cp config/mark-scan-${vx_daemon}-daemon.service /etc/systemd/system/
+    sudo cp run-scripts/run-mark-scan-${vx_daemon}-daemon.sh /vx/services/
+    sudo chmod 644 /etc/systemd/system/mark-scan-${vx_daemon}-daemon.service
+    sudo systemctl enable mark-scan-${vx_daemon}-daemon.service
+    sudo systemctl start mark-scan-${vx_daemon}-daemon.service
+  done
+fi
 
 echo "Successfully setup machine."
 

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -193,6 +193,24 @@ then
     sudo usermod -aG scanner vx-services
 fi
 
+if [ "${CHOICE}" == "mark-scan" ]
+then
+    # let vx-services use virtual uinput devices
+    getent group uinput || groupadd uinput
+    sudo cp config/50-uinput.rules /etc/udev/rules.d/
+    # uinput module must be loaded explicitly
+    sudo cp config/uinput.conf /etc/modules-load.d/uinput.conf
+    sudo usermod -aG uinput vx-services
+
+    # let vx-services use serialport devices at /dev/ttyACM<n>
+    sudo usermod -aG dialout vx-services
+
+    # let vx-services use GPIO
+    getent group gpio || groupadd gpio
+    sudo cp config/50-gpio.rules /etc/udev/rules.d/
+    sudo usermod -aG gpio vx-services
+fi
+
 echo "Setting up the code"
 sudo mv build/${CHOICE} /vx/code
 
@@ -203,7 +221,6 @@ sudo cp -rp vxsuite /vx/code/
 # symlink the code and run-*.sh in /vx/services
 sudo ln -s /vx/code/vxsuite /vx/services/vxsuite
 sudo ln -s /vx/code/run-${CHOICE}.sh /vx/services/run-${CHOICE}.sh
-
 
 # symlink appropriate vx/ui files
 sudo ln -s /vx/code/config/ui_bash_profile /vx/ui/.bash_profile

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -196,19 +196,17 @@ fi
 if [ "${CHOICE}" == "mark-scan" ]
 then
     # let vx-services use virtual uinput devices
-    getent group uinput || groupadd uinput
     sudo cp config/50-uinput.rules /etc/udev/rules.d/
-    # uinput module must be loaded explicitly
-    sudo cp config/uinput.conf /etc/modules-load.d/uinput.conf
     sudo usermod -aG uinput vx-services
+    # uinput module must be loaded explicitly
+    sudo sh -c 'echo "uinput" >> /etc/modules-load.d/modules.conf'
 
     # let vx-services use serialport devices at /dev/ttyACM<n>
     sudo usermod -aG dialout vx-services
 
     # let vx-services use GPIO
-    getent group gpio || groupadd gpio
-    sudo cp config/50-gpio.rules /etc/udev/rules.d/
     sudo usermod -aG gpio vx-services
+    sudo cp config/50-gpio.rules /etc/udev/rules.d/
 fi
 
 echo "Setting up the code"

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -137,6 +137,10 @@ sudo usermod -aG vx-group vx-services
 
 sudo usermod -aG video vx-ui
 
+# mark-scan requires access to the audio group
+sudo usermod -aG audio vx-ui
+sudo usermod -aG audio vx-services
+
 # remove all files created by default
 sudo rm -rf /vx/services/* /vx/ui/* /vx/admin/*
 

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -332,8 +332,9 @@ if [[ "${CHOICE}" == "mark-scan" ]]; then
   for vx_daemon in controller pat
   do
     sudo cp config/mark-scan-${vx_daemon}-daemon.service /etc/systemd/system/
-    sudo cp run-scripts/run-mark-scan-${vx_daemon}-daemon.sh /vx/services/
+    sudo cp run-scripts/run-mark-scan-${vx_daemon}-daemon.sh /vx/code/
     sudo chmod 644 /etc/systemd/system/mark-scan-${vx_daemon}-daemon.service
+    sudo ln -s /vx/code/run-mark-scan-${vx_daemon}-daemon.sh /vx/services/run-mark-scan-${vx_daemon}-daemon.sh
     sudo systemctl enable mark-scan-${vx_daemon}-daemon.service
     sudo systemctl start mark-scan-${vx_daemon}-daemon.service
   done

--- a/vxdev/run-vxmarkscan.desktop
+++ b/vxdev/run-vxmarkscan.desktop
@@ -2,6 +2,6 @@
 Version=1.0
 Name=VxMarkScan
 Icon=runprogram.png
-Exec=gnome-terminal -- /bin/sh -c 'env PATH=$PATH:/sbin /vx/code/vxsuite-complete-system/run.sh mark-scan'
+Exec=gnome-terminal -- /bin/sh -c 'env PATH=$PATH:/sbin env MARK_SCAN_WORKSPACE=/vx/data/module-mark-scan /vx/code/vxsuite-complete-system/run.sh mark-scan'
 Terminal=false
 Type=Application

--- a/vxdev/run-vxmarkscan.desktop
+++ b/vxdev/run-vxmarkscan.desktop
@@ -1,0 +1,7 @@
+[Desktop Entry]
+Version=1.0
+Name=VxMarkScan
+Icon=runprogram.png
+Exec=gnome-terminal -- /bin/sh -c 'env PATH=$PATH:/sbin /vx/code/vxsuite-complete-system/run.sh mark-scan'
+Terminal=false
+Type=Application

--- a/vxdev/setup-vxdev-base-machine.sh
+++ b/vxdev/setup-vxdev-base-machine.sh
@@ -56,7 +56,7 @@ sudo ln -sf /var/vx/admin /vx/admin
 # Set up vx-services user
 id -u vx-services &> /dev/null || sudo useradd -u 753 -m -d /var/vx/services -s /bin/bash vx-services
 sudo ln -sf /var/vx/services /vx/services
-
+sudo ln -sf /home/vx/code/vxsuite-complete-system/vxsuite /var/vx/services/vxsuite
 # make sure machine never shuts down on idle, and does shut down on power key (no hibernate or anything.)
 sudo cp config/logind.conf /etc/systemd/
 
@@ -65,8 +65,8 @@ echo "Creating necessary directories"
 sudo mkdir -p /vx
 sudo mkdir -p /var/vx
 sudo mkdir -p /var/vx/code
-sudo mkdir -p /var/vx/services
 sudo mkdir -p /var/vx/data/module-scan
+sudo mkdir -p /var/vx/data/module-mark-scan
 sudo mkdir -p /var/vx/data/module-sems-converter
 sudo mkdir -p /var/vx/data/admin-service
 
@@ -77,7 +77,6 @@ sudo ln -sf /var/vx/config /vx/config
 
 sudo ln -sf /var/vx/data /vx/data
 sudo ln -sf /var/vx/code /vx/code
-sudo ln -sf /var/vx/services /vx/services
 
 sudo ln -sf /vx/code/config/read-vx-machine-config.sh /vx/config/read-vx-machine-config.sh
 sudo ln -sf /home/vx/code/vxsuite-complete-system /vx/code/vxsuite-complete-system
@@ -164,6 +163,9 @@ fi
 
 # update sudoers file to give vx user special permissions
 sudo cp vxdev/sudoers /etc/sudoers
+
+# grant read and execute on vx home dir so vx-services can access daemons
+chown 755 /home/vx
 
 # turn off time synchronization
 sudo timedatectl set-ntp no

--- a/vxdev/setup-vxdev-base-machine.sh
+++ b/vxdev/setup-vxdev-base-machine.sh
@@ -165,7 +165,7 @@ fi
 sudo cp vxdev/sudoers /etc/sudoers
 
 # grant read and execute on vx home dir so vx-services can access daemons
-chown 755 /home/vx
+chmod 755 /home/vx
 
 # turn off time synchronization
 sudo timedatectl set-ntp no

--- a/vxdev/sudoers
+++ b/vxdev/sudoers
@@ -22,3 +22,4 @@ root	ALL=(ALL:ALL) ALL
 
 # fine-grained sudo permissions for certain users & actions
 vx ALL=(ALL) NOPASSWD: ALL
+vx-services ALL=(ALL) NOPASSWD: ALL

--- a/vxdev/update-code.sh
+++ b/vxdev/update-code.sh
@@ -67,7 +67,13 @@ elif [[ $BRANCH == 'custom' ]]; then
 fi
 cp /vx/config/.env.local vxsuite/.env.local
 
-make build-kiosk-browser
+# improve this by tracking commit id
+# only rebuild when it changes
+if ! which kiosk-browser >/dev/null 2>&1
+then
+	make build-kiosk-browser
+fi
+
 echo $APP_TYPE
 if [[ $APP_TYPE == 'VxCentralScan' ]] || [[ $APP_TYPE == 'VxAdminCentralScan' ]]; then
 	cp /vx/config/.env.local vxsuite/apps/central-scan/backend/.env.local

--- a/vxdev/update-code.sh
+++ b/vxdev/update-code.sh
@@ -98,6 +98,14 @@ if [[ $APP_TYPE == 'VxMarkScan' ]]; then
 	cp /vx/config/.env.local vxsuite/apps/mark-scan/frontend/.env.local
 	./prepare_build.sh mark-scan
 	./build.sh mark-scan
+	for vx_daemon in controller pat
+	do
+	  sudo cp config/mark-scan-${vx_daemon}-daemon.service /etc/systemd/system/
+	  sudo cp run-scripts/run-mark-scan-${vx_daemon}-daemon.sh /vx/code/
+	  sudo chmod 644 /etc/systemd/system/mark-scan-${vx_daemon}-daemon.service
+	  sudo ln -sf /vx/code/run-mark-scan-${vx_daemon}-daemon.sh /vx/services/run-mark-scan-${vx_daemon}-daemon.sh
+	  sudo systemctl daemon-reload
+	done
 fi
 
 echo "Done! Closing in 3 seconds."

--- a/vxdev/update-vxdev.sh
+++ b/vxdev/update-vxdev.sh
@@ -21,6 +21,9 @@ CHOICES+=('VxMark')
 echo "${#CHOICES[@]}. VxScan"
 CHOICES+=('VxScan')
 
+echo "${#CHOICES[@]}. VxMarkScan"
+CHOICES+=('VxMarkScan')
+
 echo
 read -p "Select Application: " CHOICE_INDEX
 
@@ -52,6 +55,10 @@ if [[ $CHOICE == 'VxMark' ]]; then
 	FAVORITE_ICONS="'run-vxmark.desktop'"
 fi
 if [[ $CHOICE == 'VxScan' ]]; then
+	sudo cp vxdev/run-vxscan.desktop /usr/share/applications/.
+	FAVORITE_ICONS="'run-vxscan.desktop'"
+fi
+if [[ $CHOICE == 'VxMarkScan' ]]; then
 	sudo cp vxdev/run-vxscan.desktop /usr/share/applications/.
 	FAVORITE_ICONS="'run-vxscan.desktop'"
 fi

--- a/vxdev/update-vxdev.sh
+++ b/vxdev/update-vxdev.sh
@@ -81,5 +81,8 @@ gsettings set org.gnome.shell favorite-apps "[$FAVORITE_ICONS, 'update-code.desk
 
 CHOICE="${CHOICE}" sudo -E sh -c 'echo "${CHOICE}" > /vx/config/machine-type'
 
+# vxdev daemons need this now, unlike setup_machine.sh, we use the CHOICE var
+MODEL_NAME="${CHOICE}" sudo -E sh -c 'echo "${MODEL_NAME}" > /vx/config/machine-model-name'
+
 
 echo "Done, this window will close in 3 seconds"

--- a/vxdev/update-vxdev.sh
+++ b/vxdev/update-vxdev.sh
@@ -59,8 +59,8 @@ if [[ $CHOICE == 'VxScan' ]]; then
 	FAVORITE_ICONS="'run-vxscan.desktop'"
 fi
 if [[ $CHOICE == 'VxMarkScan' ]]; then
-	sudo cp vxdev/run-vxscan.desktop /usr/share/applications/.
-	FAVORITE_ICONS="'run-vxscan.desktop'"
+	sudo cp vxdev/run-vxmarkscan.desktop /usr/share/applications/.
+	FAVORITE_ICONS="'run-vxmarkscan.desktop'"
 fi
 if [[ $CHOICE == 'VxAdmin' ]]; then
 	sudo cp vxdev/run-vxadmin.desktop /usr/share/applications/.


### PR DESCRIPTION
This PR includes mark-scan daemons (accessible-controller and pat-device-input) in the build process, and meets trusted build requirements. 

It also adds the `vx-ui` and `vx-services` users to the `audio` group to support `amixer` access.

Finally, it updates the vxsuite submodule to latest main.

In the current state, both daemons fail to run due to unrelated issues. Since those daemons are still in active development, it's fine if we hold off on merging this to main and update the vxsuite submodule one more time once daemons are ready.