### PR TITLE
Adam/esi 2.5

### DIFF
--- a/config/admin-functions/lockdown.sh
+++ b/config/admin-functions/lockdown.sh
@@ -49,8 +49,6 @@ if [[ $surface == 0 ]] && [[ -n $modules_to_sign ]]; then
   done
 fi
 
-update-initramfs -u
-
 # Since we are locking down, we need to modify /etc/crypttab to use the TPM
 # Also set the flag file to run the actual rekey_via_tpm.sh script on first boot
 # Only do this if the crypttab is already configured, just in case
@@ -60,6 +58,7 @@ if grep '^var_decrypted' /etc/crypttab > /dev/null; then
   touch /home/REKEY_VIA_TPM
 fi
 
+update-initramfs -u
 
 # Remount / so it can't change while we're doing the veritysetup
 cd /tmp

--- a/config/admin-functions/lockdown.sh
+++ b/config/admin-functions/lockdown.sh
@@ -70,7 +70,7 @@ if [[ $surface == 0 ]] && [[ -n $modules_to_sign ]]; then
 fi
 
 # Since we are locking down, we need to modify /etc/crypttab to use the TPM
-# Also set the flag file to run the actual rekey_via_tpm.sh script on first boot
+# Also set the flag file to run the actual rekey-via-tpm.sh script on first boot
 # Only do this if the crypttab is already configured, just in case
 if grep '^var_decrypted' /etc/crypttab > /dev/null; then
   sed -i -e /^var_decrypted/d /etc/crypttab

--- a/config/admin-functions/lockdown.sh
+++ b/config/admin-functions/lockdown.sh
@@ -26,6 +26,19 @@ if [[ $answer == 'n' || $answer == 'N' ]]; then
     exit
 fi
 
+# Since we shutdown after this script now, let's add a check related
+# to basic configuration on first boot
+if [[ ! -f "${VX_CONFIG_ROOT}/RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT" ]]; then
+  echo "This system is not configured to run the basic configuration wizard on first boot. Would you like to configure that now? [y/n]: "
+  read -r enable_config
+  if [[ $enable_config == 'n' || $enable_config == 'N' ]]; then
+    echo "Skipping basic configuration wizard on next boot."
+  else
+    echo "Enabling basic configuration wizard on next boot."
+    touch "${VX_CONFIG_ROOT}/RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT"
+  fi
+fi
+
 # Since this script is pretty destructive if something goes wrong
 # check that the signing keys are mounted before proceeding, exit if not
 umount /dev/sda || true

--- a/config/admin-functions/lockdown.sh
+++ b/config/admin-functions/lockdown.sh
@@ -55,7 +55,7 @@ update-initramfs -u
 # Also set the flag file to run the actual rekey_via_tpm.sh script on first boot
 # Only do this if the crypttab is already configured, just in case
 if grep '^var_decrypted' /etc/crypttab > /dev/null; then
-  sed -i -e /^var_decrypted/d 
+  sed -i -e /^var_decrypted/d /etc/crypttab
   echo "var_decrypted /dev/Vx-vg/var_encrypted none luks,tpm2-device=auto" >> /etc/crypttab
   touch /home/REKEY_VIA_TPM
 fi

--- a/config/admin-functions/lockdown.sh
+++ b/config/admin-functions/lockdown.sh
@@ -51,6 +51,16 @@ fi
 
 update-initramfs -u
 
+# Since we are locking down, we need to modify /etc/crypttab to use the TPM
+# Also set the flag file to run the actual rekey_via_tpm.sh script on first boot
+# Only do this if the crypttab is already configured, just in case
+if grep '^var_decrypted' /etc/crypttab > /dev/null; then
+  sed -i -e /^var_decrypted/d 
+  echo "var_decrypted /dev/Vx-vg/var_encrypted none luks,tpm2-device=auto" >> /etc/crypttab
+  touch /home/REKEY_VIA_TPM
+fi
+
+
 # Remount / so it can't change while we're doing the veritysetup
 cd /tmp
 mount -o ro,remount /

--- a/config/admin-functions/rekey-via-tpm.sh
+++ b/config/admin-functions/rekey-via-tpm.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
-# TODO: add more error checking
+set -euo pipefail
+
 # TODO?: support passing multiple partitions
 
 rekey_flag='/home/REKEY_VIA_TPM'

--- a/config/admin-functions/rekey_via_tpm.sh
+++ b/config/admin-functions/rekey_via_tpm.sh
@@ -1,0 +1,40 @@
+#!/bin/bash
+
+# TODO: add error checking
+# TODO?: support passing multiple partitions
+encrypted_dev_path='/dev/Vx-vg/var_encrypted'
+insecure_key='/home/insecure.key'
+random_key='/home/random.key'
+partition_path='/var'
+
+# check for flag file created by lockdown.sh only run if exists
+# check for tpm2 only run if exists
+# check for crypttab entry only run if configured for tpm
+# check for tpm2-tools installed only run if found
+
+echo "Creating a random keyfile..."
+dd if=/dev/urandom of=${random_key} bs=512 count=4
+chmod 0400 ${random_key}
+
+echo "Enrolling random keyfile to luks..."
+cryptsetup luksAddKey --key-file ${insecure_key} ${encrypted_dev_path} ${random_key}
+
+echo "Removing original passphrase..."
+cryptsetup luksRemoveKey --key-file ${insecure_key} ${encrypted_dev_path}
+
+echo "Re-encrypting ${partition_path} with random key. This will take several minutes..."
+cryptsetup reencrypt ${encrypted_dev_path} --key-file ${random_key}
+
+echo "Enrolling random key into the TPM..."
+systemd-cryptenroll --unlock-key-file=${random_key} --tpm2-device=auto ${encrypted_dev_path}
+
+echo "Removing the random keyfile from luks..."
+cryptsetup luksRemoveKey --key-file ${random_key} ${encrypted_dev_path}
+
+echo "Removing all keyfiles from disk..."
+shred -uvz ${insecure_key}
+shred -uvz ${random_key}
+
+echo "${partition_path} encryption key has been stored in the TPM."
+
+exit 0;

--- a/config/admin-functions/rekey_via_tpm.sh
+++ b/config/admin-functions/rekey_via_tpm.sh
@@ -3,8 +3,10 @@
 # TODO: add more error checking
 # TODO?: support passing multiple partitions
 
+rekey_flag='/home/REKEY_VIA_TPM'
+
 # check for flag file created by lockdown.sh only run if exists
-if [ ! -f /home/REKEY_VIA_TPM ]; then
+if [ ! -f ${rekey_flag} ]; then
   echo "NOTE: No flag file exists to encrypt via the TPM. Skipping this step."
   sleep 5
   exit 0
@@ -45,6 +47,8 @@ if ! tpm2_selftest -v > /dev/null 2>&1; then
   exit 0
 fi
 
+# TODO: add a check via luksDump to see if TPM is already in use
+
 encrypted_dev_path='/dev/Vx-vg/var_encrypted'
 insecure_key='/home/insecure.key'
 random_key='/home/random.key'
@@ -72,6 +76,8 @@ cryptsetup luksRemoveKey --key-file ${random_key} ${encrypted_dev_path}
 echo "Removing all keyfiles from disk..."
 shred -uvz ${insecure_key}
 shred -uvz ${random_key}
+
+rm -f ${rekey_flag}
 
 echo "${partition_path} encryption key has been stored in the TPM."
 

--- a/config/admin-functions/show-vx-suite-admin-menu.sh
+++ b/config/admin-functions/show-vx-suite-admin-menu.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 : "${VX_METADATA_ROOT:="/vx/code"}"
 
 if [[ $(tty) = /dev/tty1 ]] && [[ -f "/home/REKEY_VIA_TPM" ]]; then
-  sudo "${VX_FUNCTIONS_ROOT}/rekey_via_tpm.sh"
+  sudo "${VX_FUNCTIONS_ROOT}/rekey-via-tpm.sh"
 fi
 
 if [[ $(tty) = /dev/tty1 ]] && [[ -f "${VX_CONFIG_ROOT}/RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT" ]]; then

--- a/config/admin-functions/show-vx-suite-admin-menu.sh
+++ b/config/admin-functions/show-vx-suite-admin-menu.sh
@@ -9,7 +9,7 @@ set -euo pipefail
 : "${VX_METADATA_ROOT:="/vx/code"}"
 
 if [[ $(tty) = /dev/tty1 ]] && [[ -f "/home/REKEY_VIA_TPM" ]]; then
-  "${VX_FUNCTIONS_ROOT}/rekey_via_tpm.sh"
+  sudo "${VX_FUNCTIONS_ROOT}/rekey_via_tpm.sh"
 fi
 
 if [[ $(tty) = /dev/tty1 ]] && [[ -f "${VX_CONFIG_ROOT}/RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT" ]]; then

--- a/config/admin-functions/show-vx-suite-admin-menu.sh
+++ b/config/admin-functions/show-vx-suite-admin-menu.sh
@@ -8,6 +8,10 @@ set -euo pipefail
 : "${VX_CONFIG_ROOT:="/vx/config"}"
 : "${VX_METADATA_ROOT:="/vx/code"}"
 
+if [[ $(tty) = /dev/tty1 ]] && [[ -f "/home/REKEY_VIA_TPM" ]]; then
+  "${VX_FUNCTIONS_ROOT}/rekey_via_tpm.sh"
+fi
+
 if [[ $(tty) = /dev/tty1 ]] && [[ -f "${VX_CONFIG_ROOT}/RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT" ]]; then
   "${VX_FUNCTIONS_ROOT}/basic-configuration.sh"
   exit 0

--- a/config/sudoers
+++ b/config/sudoers
@@ -21,7 +21,7 @@ root	ALL=(ALL:ALL) ALL
 
 # fine-grained sudo permissions for certain users & actions
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/set-clock.sh
-vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/rekey_via_tpm.sh
+vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/rekey-via-tpm.sh
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/lockdown.sh
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/hash-signature.sh
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/generate-key.sh

--- a/config/sudoers
+++ b/config/sudoers
@@ -21,6 +21,7 @@ root	ALL=(ALL:ALL) ALL
 
 # fine-grained sudo permissions for certain users & actions
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/set-clock.sh
+vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/reset_via_tpm.sh
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/lockdown.sh
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/hash-signature.sh
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/generate-key.sh

--- a/config/sudoers
+++ b/config/sudoers
@@ -21,7 +21,7 @@ root	ALL=(ALL:ALL) ALL
 
 # fine-grained sudo permissions for certain users & actions
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/set-clock.sh
-vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/reset_via_tpm.sh
+vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/rekey_via_tpm.sh
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/lockdown.sh
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/hash-signature.sh
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/generate-key.sh

--- a/config/sudoers-for-dev
+++ b/config/sudoers-for-dev
@@ -22,6 +22,7 @@ vx-admin	ALL=(ALL:ALL) ALL
 
 # fine-grained sudo permissions for certain users & actions
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/set-clock.sh
+vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/rekey-via-tpm.sh
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/lockdown.sh
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/hash-signature.sh
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/generate-key.sh

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -333,8 +333,13 @@ echo "Successfully setup machine."
 
 USER=$(whoami)
 
+# cleanup
 sudo apt remove -y git firefox snapd
 sudo apt autoremove -y
+sudo rm -f /var/cache/apt/archives/*.deb
+sudo rm -rf /var/tmp/code 
+sudo rm -rf /var/tmp/downloads
+sudo rm -rf /var/tmp/rust*
 
 # set password for vx-admin
 (echo $ADMIN_PASSWORD; echo $ADMIN_PASSWORD) | sudo passwd vx-admin


### PR DESCRIPTION
Tightly coupled to changes in vxsuite-build-system seen here: https://github.com/votingworks/vxsuite-build-system/pull/115

Of note:

- rekey_via_tpm.sh runs on first boot and manages generating a new key, storing it in the tpm, re-encrypting the `/var` partition, and removing all passphrases and key files. The only way to decrypt `/var` is via the tpm.
- lockdown.sh now supports enabling basic machine configuration
- lockdown.sh now shuts the VM down rather than rebooting
- setup-machine.sh does additional disk cleanup related to the `/var` partition