### PR TITLE
add basic restart behavior to markscan daemons

### DIFF
--- a/config/mark-scan-controller-daemon.service
+++ b/config/mark-scan-controller-daemon.service
@@ -1,7 +1,11 @@
 [Unit]
 Description=VotingWorks daemon that handles accessible controller input.
+StartLimitIntervalSec=300
+StartLimitBurst=10
 
 [Service]
+Restart=on-failure
+RestartSec=10
 Type=simple
 User=vx-services
 Environment=VX_CONFIG_ROOT=/vx/config

--- a/config/mark-scan-pat-daemon.service
+++ b/config/mark-scan-pat-daemon.service
@@ -1,7 +1,11 @@
 [Unit]
 Description=VotingWorks daemon that handles PAT device input.
+StartLimitIntervalSec=300
+StartLimitBurst=10
 
 [Service]
+Restart=on-failure
+RestartSec=10
 Type=simple
 User=vx-services
 Environment=VX_CONFIG_ROOT=/vx/config


### PR DESCRIPTION
Adds some basic automatic restart behavior to the vxmarkscan daemons to eliminate potential race conditions during boot. 