### PR TITLE
Updates for signed hash validation

### DIFF
--- a/config/admin-functions/hash-signature.sh
+++ b/config/admin-functions/hash-signature.sh
@@ -1,9 +1,13 @@
 #!/bin/bash
 
-echo "Retrieving image signature (this may take some time)..."
-sha256sum /dev/mapper/Vx--vg-root
-echo ""
-
-read -p "Press enter once you have recorded the image signature."
+if [[ $1 == "noninteractive" ]]; then
+  hash=$(sha256sum /dev/mapper/Vx--vg-root | cut -d' ' -f1)
+  echo "$hash"
+else
+  echo "Retrieving image signature (this may take some time)..."
+  sha256sum /dev/mapper/Vx--vg-root
+  echo ""
+  read -p "Press enter once you have recorded the image signature."
+fi
 
 exit 0;

--- a/config/sudoers
+++ b/config/sudoers
@@ -35,6 +35,7 @@ vx-admin ALL=(root:ALL) NOPASSWD: /usr/sbin/reboot
 vx-services ALL=(root:ALL) NOPASSWD: /vx/code/vxsuite/libs/auth/src/intermediate-scripts/create-cert
 vx-services ALL=(root:ALL) NOPASSWD: /vx/code/vxsuite/libs/auth/src/intermediate-scripts/sign-message
 vx-services ALL=(root:ALL) NOPASSWD: /vx/code/vxsuite/libs/usb-drive/scripts/*
+vx-services ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/hash-signature.sh
 vx-ui ALL=(root:ALL) NOPASSWD: /vx/code/config/admin-functions/timedatectl
 vx-ui ALL=(root:ALL) NOPASSWD: /usr/bin/brightnessctl
 vx-ui ALL=(root:ALL) NOPASSWD: /usr/local/bin/tpm2-totp

--- a/config/sudoers-for-dev
+++ b/config/sudoers-for-dev
@@ -36,6 +36,7 @@ vx-admin ALL=(root:ALL) NOPASSWD: /vx/code/vxsuite/libs/auth/src/intermediate-sc
 vx-services ALL=(root:ALL) NOPASSWD: /vx/code/vxsuite/libs/auth/src/intermediate-scripts/create-cert
 vx-services ALL=(root:ALL) NOPASSWD: /vx/code/vxsuite/libs/auth/src/intermediate-scripts/sign-message
 vx-services ALL=(root:ALL) NOPASSWD: /vx/code/vxsuite/libs/usb-drive/scripts/*
+vx-services ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/hash-signature.sh
 vx-ui ALL=(root:ALL) NOPASSWD: /vx/code/config/admin-functions/timedatectl
 vx-ui ALL=(root:ALL) NOPASSWD: /usr/bin/brightnessctl
 vx-ui ALL=(root:ALL) NOPASSWD: /usr/local/bin/tpm2-totp


### PR DESCRIPTION
This PR adds a noninteractive option to the `hash-signature.sh` script used to generate a hash of the read-only root partition. `sudo` privileges required to run this script are also granted to the `vx-services` user. 

To run as the `vx-services` user in noninteractive mode:
```
sudo /vx/admin/admin-functions/hash-signature.sh noninteractive
```