### PR TITLE
Hide cursor on VxMarkScan

### DIFF
--- a/run-scripts/run-kiosk-browser-forever-and-log.sh
+++ b/run-scripts/run-kiosk-browser-forever-and-log.sh
@@ -18,7 +18,7 @@ source ${CONFIG}/read-vx-machine-config.sh
 : "${VX_MACHINE_TYPE:=""}"
 
 # remove pointer on screen
-if [ "${VX_MACHINE_TYPE}" = "mark" ] || [ "${VX_MACHINE_TYPE}" = "scan" ]; then
+if [ "${VX_MACHINE_TYPE}" = "mark" ] || [ "${VX_MACHINE_TYPE}" = "mark-scan" ]|| [ "${VX_MACHINE_TYPE}" = "scan" ]; then
     unclutter -idle 0.01 -root &
 fi
     


### PR DESCRIPTION
This PR hides the cursor on VxMarkScan, just like we do on VxMark and VxScan. Tested on a prod-imaged VxMarkScan.

Note that the cursor is briefly visible any time you click somewhere on the screen. I think that this is because VSAP hardware is slow. Down the road, might be nice to replace the cursor with a simple circle icon. The end result would be a briefly displayed indicator every time you tap on the screen. Lots of kiosks out there in the world do this, and I think that this pattern looks quite nice ([issue](https://github.com/votingworks/vxsuite/issues/4860)).