### PR TITLE
Fix builds

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -91,7 +91,6 @@ build() {
       "${DIR}/run-scripts/run-kiosk-browser.sh" \
       "${DIR}/run-scripts/run-kiosk-browser-forever-and-log.sh" \
       "${DIR}/config" \
-      "${DIR}/printing" \
       "${DIR}/app-scripts" \
       "${BUILD_ROOT}"
 


### PR DESCRIPTION
Quick build fix 🛠️

While running the offline phase for a VSAP build:

```
./scripts/tb-run-offline-phase.sh vsap
```

I ran into the following error:

```
cp: cannot stat '/home/vx/code/vxsuite-complete-system/printing': No such file or directory
✘ admin build failed! check the logs above
```

Looks like we deleted `vxsuite-complete-system/printing/` as part of https://github.com/votingworks/vxsuite-complete-system/pull/371 but missed a reference to that directory in `vxsuite-complete-system/build.sh`
