### PR TITLE
Prevent TPM encryption of /var if not in production secure boot state

### DIFF
--- a/config/admin-functions/rekey-via-tpm.sh
+++ b/config/admin-functions/rekey-via-tpm.sh
@@ -52,15 +52,16 @@ fi
 secure_boot_state=$(mokutil --sb-state | grep SecureBoot | cut -d' ' -f2)
 if [[ $secure_boot_state != "enabled" ]]; then
   echo "Secure Boot is not enabled. Please enable it via the BIOS."
-  echo "(VSAP may only require a reboot since the BIOS is limited.)"
+  echo "(VxMark may only require a reboot since the BIOS is limited.)"
   echo "Rebooting to BIOS in 10 seconds..."
   sleep 10
   systemctl reboot --firmware
 fi
 
 # check for VotingWorks signed PK
+# Note: The ${var,,} syntax lowercases the variable content
 secure_boot_signer=$(mokutil --pk | grep Issuer | cut -d'=' -f2)
-if [[ $secure_boot_signer != "VotingWorks PK" ]]; then
+if [[ ${secure_boot_signer,,} =~ "votingworks" ]]; then
   echo "VotingWorks secure boot keys are not installed."
   echo "Please configure the BIOS to Secure Boot Setup Mode and install the required keys."
   echo "Rebooting to BIOS in 10 seconds..."

--- a/config/admin-functions/rekey-via-tpm.sh
+++ b/config/admin-functions/rekey-via-tpm.sh
@@ -48,6 +48,26 @@ if ! tpm2_selftest -v > /dev/null 2>&1; then
   exit 0
 fi
 
+# check that Secure Boot is enabled
+secure_boot_state=$(mokutil --sb-state | grep SecureBoot | cut -d' ' -f2)
+if [[ $secure_boot_state != "enabled" ]]; then
+  echo "Secure Boot is not enabled. Please enable it via the BIOS."
+  echo "(VSAP may only require a reboot since the BIOS is limited.)"
+  echo "Rebooting to BIOS in 10 seconds..."
+  sleep 10
+  systemctl reboot --firmware
+fi
+
+# check for VotingWorks signed PK
+secure_boot_signer=$(mokutil --pk | grep Issuer | cut -d'=' -f2)
+if [[ $secure_boot_signer != "VotingWorks PK" ]]; then
+  echo "VotingWorks secure boot keys are not installed."
+  echo "Please configure the BIOS to Secure Boot Setup Mode and install the required keys."
+  echo "Rebooting to BIOS in 10 seconds..."
+  sleep 10
+  systemctl reboot --firmware
+fi
+
 # TODO: add a check via luksDump to see if TPM is already in use
 
 encrypted_dev_path='/dev/Vx-vg/var_encrypted'

--- a/config/admin-functions/rekey-via-tpm.sh
+++ b/config/admin-functions/rekey-via-tpm.sh
@@ -61,7 +61,7 @@ fi
 # check for VotingWorks signed PK
 # Note: The ${var,,} syntax lowercases the variable content
 secure_boot_signer=$(mokutil --pk | grep Issuer | cut -d'=' -f2)
-if [[ ${secure_boot_signer,,} =~ "votingworks" ]]; then
+if [[ ! ${secure_boot_signer,,} =~ "votingworks" ]]; then
   echo "VotingWorks secure boot keys are not installed."
   echo "Please configure the BIOS to Secure Boot Setup Mode and install the required keys."
   echo "Rebooting to BIOS in 10 seconds..."

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -403,6 +403,7 @@ fi
 # remove everything from this bootstrap user's home directory
 cd
 rm -rf *
+rm -rf .*
 
 echo "Machine setup is complete. Please wait for the VM to reboot."
 


### PR DESCRIPTION
The encryption key stored in the TPM is tied to PCR 7 (SecureBoot state and keys). This PR adds a couple checks to prevent performing the encryption unless VotingWorks certs are present and SecureBoot is enabled. Without these checks, it's possible to encrypt the `/var` partition while in a non-production state. Once you configure the system for production use, the encryption key will be unavailable due to the changed PCR 7 state, resulting in a failed boot since `/var` cannot be decrypted. 

(I also added one more cleanup step to recover additional disk space after the majority of `setup_machine.sh` has run.)