### PR TITLE
Set up udev rules and other related settings for PDI scanner and Fujitsu printer access

### DIFF
--- a/config/50-pdi-scanner.rules
+++ b/config/50-pdi-scanner.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="usb", ATTR{idVendor}=="0bd7", ATTR{idProduct}=="a002", MODE="0660", GROUP="scanner"

--- a/config/60-fujitsu-printer.rules
+++ b/config/60-fujitsu-printer.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="usb", ATTR{idVendor}=="0430", ATTR{idProduct}=="0626", MODE="0660", GROUP="plugdev"

--- a/config/modprobe.d/60-fujitsu-printer.conf
+++ b/config/modprobe.d/60-fujitsu-printer.conf
@@ -1,0 +1,1 @@
+blacklist usblp

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -178,7 +178,12 @@ sudo cp config/apparmor.d/usr.sbin.cupsd /etc/apparmor.d/
 sudo cp config/apparmor.d/usr.sbin.cups-browsed /etc/apparmor.d/
 
 # copy any modprobe configs we might use
-sudo cp config/modprobe.d/* /etc/modprobe.d/
+sudo cp config/modprobe.d/10-i915.conf /etc/modprobe.d/
+sudo cp config/modprobe.d/50-bluetooth.conf /etc/modprobe.d/
+if [ "${CHOICE}" == "scan" ]
+then
+    sudo cp config/modprobe.d/60-fujitsu-printer.conf /etc/modprobe.d/
+fi
 
 # load the i915 display module as early as possible
 sudo sh -c 'echo "i915" >> /etc/modules-load.d/modules.conf'
@@ -189,6 +194,13 @@ then
     sudo cp config/49-sane-missing-scanner.rules /etc/udev/rules.d/
     sudo cp config/50-custom-scanner.rules /etc/udev/rules.d/
     sudo usermod -aG scanner vx-services
+fi
+
+if [ "${CHOICE}" == "scan" ]
+then
+    sudo cp config/50-pdi-scanner.rules /etc/udev/rules.d/
+    sudo cp config/60-fujitsu-printer.rules /etc/udev/rules.d/
+    sudo usermod -aG plugdev vx-services
 fi
 
 if [ "${CHOICE}" == "mark-scan" ]


### PR DESCRIPTION
The PR covers a variety of issues that I encountered while trying to run a production image on the VxScan v4 build0, all involving PDI scanner and Fujitsu printer access. The PR specifically:

- Adds a udev rule for the PDI scanner (such that we can access it without using sudo)
- Adds a udev rule for the Fujitsu printer (such that we can access it without using sudo)
- Blocks the default printer driver from accessing the Fujitsu printer and making it such that our driver can't access it
- Adds the vx-services user to the relevant user group for Fujitsu printer access

Getting the udev rules right took some experimentation, and I'm admittedly still figuring out the exact details. But I wanted to put up my current working state for review.

The key factors that I experimented with to get things working were 1) the use of `ATTRS` vs. `ATTR` and 2) the numeric prefixes in the rule's file names.

`ATTR` matches an attribute of a device whereas `ATTRS` matches an attribute of a device _or_ any of its parent devices. I think this means that `ATTR` is stricter than `ATTRS`. And if not used carefully, `ATTRS` can end up matching more than intended.

The numeric prefixes in the rule's file names provide a way to explicitly sort the rules. Rules are run in alphabetical/lexicographical order, and later rules can override earlier rules.

In my first attempt at udev rules, I'd used `ATTRS` in both the PDI and Fujitsu rules, and I'd used `50` as the numeric prefix for both files. This means that the `50-pdi-scanner` rule may have been interfering with the `50-fujitsu-printer` rule, `50-pdi-scanner` coming later alphabetically.

I think the core fix was probably just switching to `ATTR` (singular) in both rules. But I also changed the file name of the Fujitsu printer rule to be `60-fujitsu-printer` to make the order of application of udev rules explicit.

Definitely more to explore here, not just with these new rules but existing ones too, so I've opened an issue to [audit our udev rules and clean them up as needed](https://github.com/votingworks/vxsuite/issues/4998).