### PR TITLE
remove old printing config dir

### DIFF
--- a/vxdev/setup-vxdev-base-machine.sh
+++ b/vxdev/setup-vxdev-base-machine.sh
@@ -100,7 +100,6 @@ sudo cp -rp \
   "${DIR}/../run-scripts/run-kiosk-browser.sh" \
   "${DIR}/../run-scripts/run-kiosk-browser-forever-and-log.sh" \
   "${DIR}/../config" \
-  "${DIR}/../printing" \
   "${DIR}/../app-scripts" \
   "/vx/code"
 


### PR DESCRIPTION
VxDev is still referencing an old directory. Remove it from the setup script. 