### PR TITLE
Panic on any kernel error and force a restart on dm-verity error

### DIFF
--- a/config/cmdline
+++ b/config/cmdline
@@ -1,1 +1,1 @@
-root=/dev/mapper/vroot ro quiet vt.handoff=7 fsck.mode=skip verity.hashdev=/dev/mapper/Vx--vg-hashes verity.rootdev=/dev/mapper/Vx--vg-root verity.hash=
+root=/dev/mapper/vroot ro quiet vt.handoff=7 fsck.mode=skip panic=3 verity.error_behavior=restart verity.hashdev=/dev/mapper/Vx--vg-hashes verity.rootdev=/dev/mapper/Vx--vg-root verity.hash=


### PR DESCRIPTION
To test, install an image built with the changes included in the PR, then boot via vx-iso, remount the root filesystem with rw access (you will need to use `vgchange -ay` to make the volume active before using it), and make a simple change, e.g. `touch /test.txt`. Reboot, verify that verity is locked in a reboot loop. 

(Also added a generic kernel panic with a 3 second delay)