### PR TITLE
add udev rules for FAI 100 USB device

### DIFF
--- a/config/55-fai100.rules
+++ b/config/55-fai100.rules
@@ -1,2 +1,1 @@
 ATTRS{idVendor}=="28cd", ATTRS{idProduct}=="4002", MODE="0664", GROUP="fai100"
-

--- a/config/55-fai100.rules
+++ b/config/55-fai100.rules
@@ -1,0 +1,2 @@
+ATTRS{idVendor}=="28cd", ATTRS{idProduct}=="4002", MODE="0664", GROUP="fai100"
+

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -208,19 +208,24 @@ then
     # create groups if they don't already exist
     sudo getent group uinput || sudo groupadd uinput
     sudo getent group gpio || sudo groupadd gpio
+    sudo getent group fai100 || sudo groupadd fai100
 
-    # let vx-services use virtual uinput devices
+    # let vx-services use virtual uinput devices for all mark-scan BMD models
     sudo cp config/50-uinput.rules /etc/udev/rules.d/
     sudo usermod -aG uinput vx-services
     # uinput module must be loaded explicitly
     sudo sh -c 'echo "uinput" >> /etc/modules-load.d/modules.conf'
 
-    # let vx-services use serialport devices at /dev/ttyACM<n>
+    # let vx-services use serialport devices at /dev/ttyACM<n> for BMD 155
     sudo usermod -aG dialout vx-services
 
-    # let vx-services use GPIO
+    # let vx-services use GPIO for BMD 155
     sudo usermod -aG gpio vx-services
     sudo cp config/50-gpio.rules /etc/udev/rules.d/
+
+    # let vx-services use FAI-100 controller on BMD 150
+    sudo usermod -aG fai100 vx-services
+    sudo cp config/55-fai100.rules /etc/udev/rules.d/
 fi
 
 echo "Setting up the code"


### PR DESCRIPTION
Adds a udev rule for the FAI-100 controller/PAT input USB device (`vid:pid` `28cd:4002`).

The rule is very targeted and might need to be expanded later if we want to support front LEDs on the BMD 150, for example. But for now it didn't seem to fit into any of the other udev rules. If you want to group some of these peripheral rules together just let me know and I will update.