### PR TITLE
Enable Screen Recording in TTY2 in QA Images

### DIFF
--- a/config/admin-functions/copy-recordings.sh
+++ b/config/admin-functions/copy-recordings.sh
@@ -2,7 +2,7 @@
 
 set -euo pipefail
 
-echo "Let's copy the logs to a USB stick."
+echo "Let's copy the screen recordings to a USB stick."
 
 # check for USB stick
 DEVICES=$( readlink -f $( ls /dev/disk/by-id/usb*part* 2>/dev/null || echo "") 2>/dev/null || echo "")
@@ -24,16 +24,14 @@ then
 fi
 
 # create a directory
-DIRECTORY="$MOUNTPOINT/logs-$( date +%Y%m%d-%H%M%S )"
+DIRECTORY="$MOUNTPOINT/screen-recordings"
 mkdir -p "$DIRECTORY"
 
-# copy logs
-cp -r /var/log/votingworks/syslog* "$DIRECTORY"
-cp -r /var/log/votingworks/auth.log* "$DIRECTORY"
-cp -r /var/log/votingworks/vx-logs.log* "$DIRECTORY"
+# copy recordings
+sudo sh -c "cp /var/vx/ui/screen-recordings/*.mp4 $DIRECTORY"
 
 # unmount the USB stick to make sure it's all written to disk
-echo "Saving logs to USB drive..."
+echo "Saving to USB drive and unmounting..."
 sync $MOUNTPOINT
 sudo /vx/code/app-scripts/unmount-usb.sh
 

--- a/config/admin-functions/show-vx-suite-admin-menu.sh
+++ b/config/admin-functions/show-vx-suite-admin-menu.sh
@@ -37,7 +37,6 @@ while true; do
   if [ "${VX_MACHINE_TYPE}" = "mark" ]; then
     echo -e "Machine App Mode: \e[32m${VX_APP_MODE}\e[0m"
   fi
-
   # TODO: do we want to try to also display secure boot status? 
   if [[ $(lsblk | grep "vroot") ]]; then
     echo -e "Lockdown State: \e[32mLocked Down\e[0m"
@@ -50,6 +49,12 @@ while true; do
   else
     echo -e "Secure Boot State: \e[31mDisabled\e[0m"
     fi
+  if [ "${IS_QA_IMAGE}" = "1" ]; then
+    echo -e "QA Image, sudo privileges are enabled."
+  else
+    echo -e "Production Image"
+  fi
+
   echo -e
 
   echo "Current Time: $(date)"
@@ -114,6 +119,14 @@ while true; do
   if [ "${VX_MACHINE_TYPE}" = "mark" ]; then
     echo "${#CHOICES[@]}. Set App Mode"
     CHOICES+=('set-app-mode')
+  fi
+
+  if [ "${IS_QA_IMAGE}" = "1" ]; then
+    echo "${#CHOICES[@]}. Start Screen Recording"
+    CHOICES+=('start-recording')
+
+    echo "${#CHOICES[@]}. Copy all Screen Recordings to USB"
+    CHOICES+=('copy-recordings')
   fi
 
   echo "0. Reboot"
@@ -212,6 +225,16 @@ while true; do
     
     setup-boot-entry)
       sudo "${VX_FUNCTIONS_ROOT}/setup-boot-entry.sh"
+      read -s -n 1
+    ;;
+
+    start-recording)
+      sudo "${VX_FUNCTIONS_ROOT}/start-screen-recording.sh"
+      read -s -n 1
+    ;;
+
+    copy-recordings)
+      sudo "${VX_FUNCTIONS_ROOT}/copy-recordings.sh"
       read -s -n 1
     ;;
 

--- a/config/admin-functions/start-screen-recording.sh
+++ b/config/admin-functions/start-screen-recording.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+USER="vx-ui" # Since we want to record the tty1 screen we have to act as the vx-ui user
+
+echo "Starting to record the screen, when you are done with your recording press Q to exit"
+sleep 1
+RECORDING_DIR=/var/vx/ui/screen-recordings
+
+sudo su $USER -c "mkdir -p $RECORDING_DIR"
+
+FILENAME="recording-$(date '+%Y-%m-%d-%H-%M-%S').mp4"
+OUTPUT_FILE="$RECORDING_DIR/$FILENAME"
+
+sudo su $USER -c "ffmpeg -f x11grab -framerate 25 -i :0.0 -preset fast $OUTPUT_FILE"

--- a/config/read-vx-machine-config.sh
+++ b/config/read-vx-machine-config.sh
@@ -33,6 +33,12 @@ if [ ! -f "${VX_METADATA_ROOT}/code-tag" ]; then
   exit 1
 fi
 
+
+if [ ! -f "${VX_CONFIG_ROOT}/is-qa-image" ]; then
+  echo "expected 'is-qa-image' file in ${VX_CONFIG_ROOT} but it could not be found" >&2
+  exit 1
+fi
+
 export VX_CONFIG_ROOT="${VX_CONFIG_ROOT}"
 export VX_MACHINE_ID="$(< "${VX_CONFIG_ROOT}/machine-id")"
 export VX_MACHINE_TYPE="$(< "${VX_CONFIG_ROOT}/machine-type")"
@@ -40,6 +46,7 @@ export VX_MACHINE_MANUFACTURER="$(< "${VX_CONFIG_ROOT}/machine-manufacturer")"
 export VX_MACHINE_MODEL_NAME="$(< "${VX_CONFIG_ROOT}/machine-model-name")"
 export VX_CODE_VERSION="$(< "${VX_METADATA_ROOT}/code-version")"
 export VX_CODE_TAG="$(< "${VX_METADATA_ROOT}/code-tag")"
+export IS_QA_IMAGE="$(< "${VX_CONFIG_ROOT}/is-qa-image")"
 
 if [ -f "${VX_CONFIG_ROOT}/app-mode" ]; then
   export VX_APP_MODE="$(< "${VX_CONFIG_ROOT}/app-mode")"

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -54,31 +54,34 @@ MODEL_NAME=${MODEL_NAMES[$CHOICE_INDEX]}
 echo "Excellent, let's set up ${CHOICE}."
 
 echo
-echo "Next, we need to set the admin password for this machine."
-while true; do
-    read -s -p "Set vx-admin password: " ADMIN_PASSWORD
-    echo
-    read -s -p "Confirm vx-admin password: " CONFIRM_PASSWORD
-    echo
-    if [[ "${ADMIN_PASSWORD}" = "${CONFIRM_PASSWORD}" ]]
-    then
-        echo "Password confirmed."
-        break
-    else
-        echo "Passwords do not match, try again."
-    fi
-done
-
-echo
-read -p "Finally, is this image for QA where you want sudo privledges, the ability to record screengrabs, etc.? [y/N]" qa_image_flag
+read -p "Is this image for QA where you want sudo privileges, the ability to record screengrabs, etc.? [y/N]" qa_image_flag
 
 if [[ $qa_image_flag == 'y' || $qa_image_flag == 'Y' ]]; then
     VXADMIN_SUDO=1
+    ADMIN_PASSWORD='insecure'
     echo "OK, creating a QA image with vx-admin sudo privileges."
+    echo "Using password insecure for vx-admin user."
 else
     VXADMIN_SUDO=0
     echo "Ok, creating a production image. No sudo privileges for anyone!"
+    echo
+    echo "Next, we need to set the admin password for this machine."
+    while true; do
+        read -s -p "Set vx-admin password: " ADMIN_PASSWORD
+        echo
+        read -s -p "Confirm vx-admin password: " CONFIRM_PASSWORD
+        echo
+        if [[ "${ADMIN_PASSWORD}" = "${CONFIRM_PASSWORD}" ]]
+        then
+            echo "Password confirmed."
+            break
+        else
+            echo "Passwords do not match, try again."
+        fi
+    done
 fi
+
+
 
 echo
 echo "The script will take it from here and set up the machine."

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -70,14 +70,14 @@ while true; do
 done
 
 echo
-read -p "Finally, do you want sudo privileges for vx-admin (only for dev purposes)? [y/N]: " vxadmin_sudo_raw
+read -p "Finally, is this image for QA where you want sudo privledges, the ability to record screengrabs, etc.? [y/N]" qa_image_flag
 
-if [[ $vxadmin_sudo_raw == 'y' || $vxadmin_sudo_raw == 'Y' ]]; then
+if [[ $qa_image_flag == 'y' || $qa_image_flag == 'Y' ]]; then
     VXADMIN_SUDO=1
-    echo "OK, giving vx-admin sudo privileges."
+    echo "OK, creating a QA image with vx-admin sudo privileges."
 else
     VXADMIN_SUDO=0
-    echo "No sudo privileges for anyone!"
+    echo "Ok, creating a production image. No sudo privileges for anyone!"
 fi
 
 echo
@@ -281,6 +281,9 @@ GIT_HASH=$(git rev-parse HEAD | cut -c -10) sudo -E sh -c 'echo "$(date +%Y.%m.%
 
 # code tag, e.g. "m11c-rc3"
 GIT_TAG=$(git tag --points-at HEAD) sudo -E sh -c 'echo "${GIT_TAG}" > /vx/code/code-tag'
+
+# qa image flag, 0 (prod image) or 1 (qa image)
+IS_QA_IMAGE="${VXADMIN_SUDO}" sudo -E sh -c 'echo "${IS_QA_IMAGE}" > /vx/config/is-qa-image'
 
 # machine ID
 sudo sh -c 'echo "0000" > /vx/config/machine-id'


### PR DESCRIPTION
Depends on https://github.com/votingworks/vxsuite-build-system/pull/125

This PR adds the ability to make screen recordings and copy them to the usb in tty2 on QA images and changes the language of the setup-machine script to make "qa images." For now this just sets a flag that is then shown in TTY2 and allows for screen recording. In the future we can do more things. In the future it would be nice to have the value from the build-system inventory auto-populate this flag instead of having to prompt the user, but this works for now. 

Tested by making QA images end to end and recording from them. 