### PR TITLE
Fix vxscan flicker

### DIFF
--- a/config/10-intel-xorg.conf
+++ b/config/10-intel-xorg.conf
@@ -1,0 +1,5 @@
+Section "Device"
+	Identifier "Intel Graphics"
+	Driver "modesetting"
+	Option "AccelMethod" "uxa"
+EndSection

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -191,6 +191,20 @@ fi
 # load the i915 display module as early as possible
 sudo sh -c 'echo "i915" >> /etc/modules-load.d/modules.conf'
 
+# On non-vsap systems, there can be varying levels of screen flickering
+# depending on the system components. To fix it, we use an xorg config
+# that switches the acceleration method to uxa instead of sna
+# Note: The logic below is not an ideal long-term solution since it's 
+# possible a future mark or mark-scan system would also have this issue.
+# As of now (202402725), we use VSAP units that do not exhibit flickering
+# and applying this change can not be used on them without causing other
+# undesireable graphical behaviors. Longer term, it would be better to 
+# detect during initial boot whether to apply this xorg config.
+if [ "${CHOICE}" != "mark" ] && [ "${CHOICE}" != "mark-scan" ]
+then
+    sudo cp config/10-intel-xorg.conf /etc/X11/xorg.conf.d/10-intel.conf
+fi
+
 # let vx-services scan
 if [ "${CHOICE}" != "mark" ]
 then


### PR DESCRIPTION
This PR implements a fix for initial screen flickering after initial boot or resetting kiosk-browser. As noted in `setup-machine.sh`, this is not an ideal long term fix since we are likely to have `mark` and/or `mark-scan` systems with an intel card that experiences this flicker. For now though, putting this configuration on our other machine types resolves the problem for the foreseeable future. 

The xorg config changes the acceleration method from the default of `sna` (the newer backend) to `uxa` (the previous, more backwards compatible backend). We've run into other flickering on certain intel cards that were fixed with setting options on the i915 module, but those were insufficient on our latest VxScan / VxComputer hardware.