### PR TITLE
add run script and config for fai-100 daemon

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -120,7 +120,17 @@ for app in "${APPS_TO_BUILD[@]}"; do
   # mark-scan has additional daemons that need to be built
   # crates were fetched while online, now we build the release while offline
   if [[ "${app}" == "mark-scan" ]]; then
-    for vx_daemon in accessible-controller pat-device-input fai-100-controller
+    # default to 155 daemons
+    vx_daemons="accessible-controller pat-device-input"
+    vxsuite_env_file="${DIR}/vxsuite/.env"
+
+    # check for the 150 env var to build the 150 daemon instead
+    if grep REACT_APP_VX_MARK_SCAN_USE_BMD_150 $vxsuite_env_file | grep -i true > /dev/null 2>&1
+    then
+      vx_daemons="fai-100-controller"
+    fi
+
+    for vx_daemon in ${vx_daemons}
     do
       cd "${DIR}/vxsuite/apps/mark-scan/${vx_daemon}"
       mkdir -p target && cargo build --offline --release --target-dir target/.

--- a/build.sh
+++ b/build.sh
@@ -120,7 +120,7 @@ for app in "${APPS_TO_BUILD[@]}"; do
   # mark-scan has additional daemons that need to be built
   # crates were fetched while online, now we build the release while offline
   if [[ "${app}" == "mark-scan" ]]; then
-    for vx_daemon in accessible-controller pat-device-input
+    for vx_daemon in accessible-controller pat-device-input fai-100-controller
     do
       cd "${DIR}/vxsuite/apps/mark-scan/${vx_daemon}"
       mkdir -p target && cargo build --offline --release --target-dir target/.

--- a/config/mark-scan-fai-100-daemon.service
+++ b/config/mark-scan-fai-100-daemon.service
@@ -1,0 +1,20 @@
+[Unit]
+Description=VotingWorks daemon that handles BMD 150 controller and PAT signal.
+StartLimitIntervalSec=300
+StartLimitBurst=10
+
+[Service]
+Restart=on-failure
+RestartSec=10
+Type=simple
+User=vx-services
+Environment=VX_CONFIG_ROOT=/vx/config
+Environment=VX_METADATA_ROOT=/vx/code
+Environment=MARK_SCAN_WORKSPACE=/vx/data/module-mark-scan
+ExecStart=/bin/bash /vx/services/run-mark-scan-fai-100-daemon.sh
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=votingworksapp
+
+[Install]
+WantedBy=multi-user.target

--- a/prepare_build.sh
+++ b/prepare_build.sh
@@ -111,7 +111,7 @@ for app in "${APPS_TO_BUILD[@]}"; do
   # mark-scan has additional daemons that need to be built
   # so we fetch their Rust crates while online
   if [[ "${app}" == "mark-scan" ]]; then
-    for vx_daemon in accessible-controller pat-device-input
+    for vx_daemon in accessible-controller pat-device-input fai-100-controller
     do
       cd "${DIR}/vxsuite/apps/mark-scan/${vx_daemon}"
       cargo fetch

--- a/prepare_build.sh
+++ b/prepare_build.sh
@@ -111,7 +111,17 @@ for app in "${APPS_TO_BUILD[@]}"; do
   # mark-scan has additional daemons that need to be built
   # so we fetch their Rust crates while online
   if [[ "${app}" == "mark-scan" ]]; then
-    for vx_daemon in accessible-controller pat-device-input fai-100-controller
+    # default to 155 daemons
+    vx_daemons="accessible-controller pat-device-input"
+    vxsuite_env_file="${DIR}/vxsuite/.env"
+
+    # check for the 150 env var to build the 150 daemon instead
+    if grep REACT_APP_VX_MARK_SCAN_USE_BMD_150 $vxsuite_env_file | grep -i true > /dev/null 2>&1
+    then
+      vx_daemons="fai-100-controller"
+    fi
+
+    for vx_daemon in ${vx_daemons}
     do
       cd "${DIR}/vxsuite/apps/mark-scan/${vx_daemon}"
       cargo fetch

--- a/run-scripts/run-mark-scan-fai-100-daemon.sh
+++ b/run-scripts/run-mark-scan-fai-100-daemon.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# go to directory where this file is located
+cd "$(dirname "$0")"
+
+# configuration information
+CONFIG=${VX_CONFIG_ROOT:-./config}
+METADATA=${VX_METADATA_ROOT:-./}
+source ${CONFIG}/read-vx-machine-config.sh
+
+(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/mark-scan/accessible-controller run) | logger --tag votingworksapp

--- a/run-scripts/run-mark-scan-fai-100-daemon.sh
+++ b/run-scripts/run-mark-scan-fai-100-daemon.sh
@@ -10,4 +10,4 @@ CONFIG=${VX_CONFIG_ROOT:-./config}
 METADATA=${VX_METADATA_ROOT:-./}
 source ${CONFIG}/read-vx-machine-config.sh
 
-(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/mark-scan/accessible-controller run) | logger --tag votingworksapp
+(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/mark-scan/fai-100-controller run) | logger --tag votingworksapp

--- a/run.sh
+++ b/run.sh
@@ -55,7 +55,7 @@ if [[ " ${ALL_APPS[@]} " =~ " ${APP} " ]]; then
   # reload their daemon configs and then issue restart commands
   if [[ "${APP}" == "mark-scan" ]]; then
     sudo systemctl daemon-reload
-    for vx_daemon in controller pat
+    for vx_daemon in controller pat fai-100
     do
       sudo systemctl restart mark-scan-${vx_daemon}-daemon.service
     done

--- a/run.sh
+++ b/run.sh
@@ -55,7 +55,18 @@ if [[ " ${ALL_APPS[@]} " =~ " ${APP} " ]]; then
   # reload their daemon configs and then issue restart commands
   if [[ "${APP}" == "mark-scan" ]]; then
     sudo systemctl daemon-reload
-    for vx_daemon in controller pat fai-100
+
+    # default to 155 daemons
+    vx_daemons="controller pat"
+    vxsuite_env_file="/vx/code/vxsuite/.env"
+
+    # check for the 150 env var to use 150 daemon
+    if grep REACT_APP_VX_MARK_SCAN_USE_BMD_150 $vxsuite_env_file | grep -i true > /dev/null 2>&1
+    then
+      vx_daemons="fai-100"
+    fi
+
+    for vx_daemon in ${vx_daemons}
     do
       sudo systemctl restart mark-scan-${vx_daemon}-daemon.service
     done

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -387,7 +387,17 @@ sudo systemctl start ${CHOICE}.service
 
 # mark-scan requires additional service daemons
 if [[ "${CHOICE}" == "mark-scan" ]]; then
-  for vx_daemon in controller pat
+  # default to 155 daemons
+  vx_daemons="controller pat"
+  vxsuite_env_file="/vx/code/vxsuite/.env"
+
+  # check for the 150 env var to use 150 daemon
+  if grep REACT_APP_VX_MARK_SCAN_USE_BMD_150 $vxsuite_env_file | grep -i true > /dev/null 2>&1
+  then
+    vx_daemons="fai-100"
+  fi 
+
+  for vx_daemon in ${vx_daemons}
   do
     sudo cp config/mark-scan-${vx_daemon}-daemon.service /etc/systemd/system/
     sudo cp run-scripts/run-mark-scan-${vx_daemon}-daemon.sh /vx/code/


### PR DESCRIPTION
Adds service config and run script for the FAI-100 daemon on the BMD 150. The FAI 100 replaces both `controllerd` and `patinputd` on the BMD 155 model.