### PR TITLE
Use dm-verity for signed hash validation

### DIFF
--- a/config/admin-functions/hash-signature.sh
+++ b/config/admin-functions/hash-signature.sh
@@ -1,12 +1,21 @@
 #!/bin/bash
 
+verity_hash=$(cat /proc/cmdline | awk -F'verity.hash=' '{print $2}' | cut -d' ' -f1)
+verity_result="UNVERIFIED"
+
+if [[ ! -z ${verity_hash} ]]; then
+  verity_root_device=$(cat /proc/cmdline | awk -F'verity.rootdev=' '{print $2}' | cut -d' ' -f1)
+  verity_hash_device=$(cat /proc/cmdline | awk -F'verity.hashdev=' '{print $2}' | cut -d' ' -f1)
+  verify_result=$(veritysetup verify ${verity_root_device} ${verity_hash_device} ${verity_hash} > /dev/null 2>&1)
+  if [[ $? -eq 0 ]]; then
+    verity_result="$verity_hash"
+  fi
+fi
+
 if [[ $1 == "noninteractive" ]]; then
-  hash=$(sha256sum /dev/mapper/Vx--vg-root | cut -d' ' -f1)
-  echo "$hash"
+  echo "$verity_result"
 else
-  echo "Retrieving image signature (this may take some time)..."
-  sha256sum /dev/mapper/Vx--vg-root
-  echo ""
+  echo "$verity_result"
   read -p "Press enter once you have recorded the image signature."
 fi
 

--- a/config/admin-functions/hash-signature.sh
+++ b/config/admin-functions/hash-signature.sh
@@ -4,12 +4,16 @@ verity_hash=$(cat /proc/cmdline | awk -F'verity.hash=' '{print $2}' | cut -d' ' 
 verity_result="UNVERIFIED"
 
 if [[ ! -z ${verity_hash} ]]; then
-  verity_root_device=$(cat /proc/cmdline | awk -F'verity.rootdev=' '{print $2}' | cut -d' ' -f1)
-  verity_hash_device=$(cat /proc/cmdline | awk -F'verity.hashdev=' '{print $2}' | cut -d' ' -f1)
-  verify_result=$(veritysetup verify ${verity_root_device} ${verity_hash_device} ${verity_hash} > /dev/null 2>&1)
-  if [[ $? -eq 0 ]]; then
-    verity_result="$verity_hash"
-  fi
+  verity_result="$verity_hash"
+
+  # If we need to provide a live verification, the code below can enable that functionality
+  # For now, we are simply returning the hash found in /proc/cmdline
+  #verity_root_device=$(cat /proc/cmdline | awk -F'verity.rootdev=' '{print $2}' | cut -d' ' -f1)
+  #verity_hash_device=$(cat /proc/cmdline | awk -F'verity.hashdev=' '{print $2}' | cut -d' ' -f1)
+  #verify_result=$(veritysetup verify ${verity_root_device} ${verity_hash_device} ${verity_hash} > /dev/null 2>&1)
+  #if [[ $? -eq 0 ]]; then
+    #verity_result="$verity_hash"
+  #fi
 fi
 
 if [[ $1 == "noninteractive" ]]; then

--- a/config/admin-functions/lockdown.sh
+++ b/config/admin-functions/lockdown.sh
@@ -135,7 +135,8 @@ else
 fi
 
 # Generate the read-only hash
-bash "${VX_FUNCTIONS_ROOT}/hash-signature.sh"
+echo "Hash: ${HASH}"
+read -p "Press enter once you have recorded the system hash."
 
 # Shut down the locked down system
 # We can't reboot this on the aws build machine due to encrypted /var

--- a/config/admin-functions/lockdown.sh
+++ b/config/admin-functions/lockdown.sh
@@ -134,7 +134,7 @@ else
     chmod -w /boot/grub/grub.cfg
 fi
 
-# Generate the read-only hash
+# Output the dm-verity hash
 echo "Hash: ${HASH}"
 read -p "Press enter once you have recorded the system hash."
 


### PR DESCRIPTION
This PR converts our signed hash validation process to use dm-verity instead of the sha256sum of the root partition. On locked down systems, we extract the hash from `/proc/cmdline` and return it. I have also included the (commented out) steps needed to perform live verification of a system if that becomes necessary in the future.