### PR TITLE
Add logic for rebooting to the vendor menu

### DIFF
--- a/config/admin-functions/show-vx-suite-admin-menu.sh
+++ b/config/admin-functions/show-vx-suite-admin-menu.sh
@@ -25,8 +25,8 @@ fi
 
 # If the machine was rebooted into the vendor menu, clear the relevant flag such that the machine
 # won't boot into the vendor menu on next boot
-if grep -q 1 "${VX_CONFIG_ROOT}/REBOOT_TO_VENDOR_MENU"; then
-  echo 0 > "${VX_CONFIG_ROOT}/REBOOT_TO_VENDOR_MENU"
+if [[ -f "${VX_CONFIG_ROOT}/app-flags/REBOOT_TO_VENDOR_MENU" ]]; then
+  rm -f "${VX_CONFIG_ROOT}/app-flags/REBOOT_TO_VENDOR_MENU"
 fi
 
 prompt-to-restart() {

--- a/config/admin-functions/show-vx-suite-admin-menu.sh
+++ b/config/admin-functions/show-vx-suite-admin-menu.sh
@@ -23,6 +23,12 @@ if [[ $(tty) = /dev/tty1 ]] && [[ -f "${VX_CONFIG_ROOT}/RUN_BASIC_CONFIGURATION_
   exit 0
 fi
 
+# If the machine was rebooted into the vendor menu, clear the relevant flag such that the machine
+# won't boot into the vendor menu on next boot
+if grep -q 1 "${VX_CONFIG_ROOT}/REBOOT_TO_VENDOR_MENU"; then
+  echo 0 > "${VX_CONFIG_ROOT}/REBOOT_TO_VENDOR_MENU"
+fi
+
 prompt-to-restart() {
   read -s -e -n 1 -p "Success! You must reboot for this change to take effect. Reboot now? (y/n) "
   if [[ ${REPLY} = "" || ${REPLY} = Y || ${REPLY} = y ]]; then

--- a/config/autologin.sh
+++ b/config/autologin.sh
@@ -3,7 +3,7 @@
 # This script is designed to be run in override.conf file for the service getty@tty1.
 # It conditionally selects which user to automatically log in as, based on whether or not the
 # machine 1) needs configuration or 2) is being rebooted into the vendor menu.
-if [[ -f /vx/config/RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT ]] || grep -q 1 /vx/config/REBOOT_TO_VENDOR_MENU; then
+if [[ -f /vx/config/RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT ]] || [[ -f /vx/config/app-flags/REBOOT_TO_VENDOR_MENU ]]; then
     USER=vx-admin
 else
     USER=vx-ui

--- a/config/autologin.sh
+++ b/config/autologin.sh
@@ -1,9 +1,9 @@
 #!/bin/bash
 
 # This script is designed to be run in override.conf file for the service getty@tty1.
-# It conditionally selects which user to autologin based on whether or not the
-# machine needs configuration.
-if [[ -f /vx/config/RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT ]]; then
+# It conditionally selects which user to automatically log in as, based on whether or not the
+# machine 1) needs configuration or 2) is being rebooted into the vendor menu.
+if [[ -f /vx/config/RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT ]] || grep -q 1 /vx/config/REBOOT_TO_VENDOR_MENU; then
     USER=vx-admin
 else
     USER=vx-ui

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -285,6 +285,7 @@ sudo ln -s /vx/code/config/grub.cfg /vx/admin/config/grub.cfg
 
 # machine configuration
 sudo mkdir -p /var/vx/config
+sudo mkdir /var/vx/config/app-flags
 sudo ln -sf /var/vx/config /vx/config
 
 sudo ln -s /vx/code/config/read-vx-machine-config.sh /vx/config/read-vx-machine-config.sh
@@ -346,13 +347,12 @@ sudo chown -R vx-services:vx-services /var/vx/data
 sudo chmod -R u=rwX /var/vx/data
 sudo chmod -R go-rwX /var/vx/data
 
-# Config is writable by the vx-admin user and readable/executable by all vx-* users.
-# /vx/config/REBOOT_TO_VENDOR_MENU is special-cased to be writable by all vx-* users.
-sudo echo 0 > /var/vx/config/REBOOT_TO_VENDOR_MENU
+# Config is writable by the vx-admin user and readable/executable by all vx-* users, with the
+# exception of the app-flags subdirectory, which is special-cased to be writable by all vx-* users
 sudo chown -R vx-admin:vx-group /var/vx/config
 sudo chmod -R u=rwX /var/vx/config
-sudo chmod -R g=rX  /var/vx/config
-sudo chmod    g=rwX /var/vx/config/REBOOT_TO_VENDOR_MENU
+sudo chmod -R g=rX /var/vx/config
+sudo chmod -R g=rwX /var/vx/config/app-flags
 sudo chmod -R o-rwX /var/vx/config
 
 # non-graphical login

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -54,7 +54,7 @@ MODEL_NAME=${MODEL_NAMES[$CHOICE_INDEX]}
 echo "Excellent, let's set up ${CHOICE}."
 
 echo
-read -p "Is this image for QA where you want sudo privileges, the ability to record screengrabs, etc.? [y/N]" qa_image_flag
+read -p "Is this image for QA where you want sudo privileges, the ability to record screengrabs, etc.? [y/N] " qa_image_flag
 
 if [[ $qa_image_flag == 'y' || $qa_image_flag == 'Y' ]]; then
     VXADMIN_SUDO=1

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -346,10 +346,13 @@ sudo chown -R vx-services:vx-services /var/vx/data
 sudo chmod -R u=rwX /var/vx/data
 sudo chmod -R go-rwX /var/vx/data
 
-# config readable & executable by all vx users, writable by admin.
+# Config is writable by the vx-admin user and readable/executable by all vx-* users.
+# /vx/config/REBOOT_TO_VENDOR_MENU is special-cased to be writable by all vx-* users.
+sudo echo 0 > /var/vx/config/REBOOT_TO_VENDOR_MENU
 sudo chown -R vx-admin:vx-group /var/vx/config
 sudo chmod -R u=rwX /var/vx/config
-sudo chmod -R g=rX /var/vx/config
+sudo chmod -R g=rX  /var/vx/config
+sudo chmod    g=rwX /var/vx/config/REBOOT_TO_VENDOR_MENU
 sudo chmod -R o-rwX /var/vx/config
 
 # non-graphical login


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/4760

This PR completes the logic for rebooting to the vendor menu, i.e., rebooting to what we currently think of as the TTY2 menu in TTY1. The step-by-step flow is this:

1. Vendor authenticates with vendor card and clicks "Reboot to Vendor Menu"
2. VxSuite backend create a `/vx/config/app-flags/REBOOT_TO_VENDOR_MENU` file as the `vx-services` user and reboots (done in https://github.com/votingworks/vxsuite/pull/5419)
3. VxSuite sees this file flag on boot and automatically logs in as the `vx-admin` user
4. The `vx-admin` user is configured to auto-run the `show-vx-suite-admin-menu.sh` script (existing logic)
5. This script removes the `/vx/config/app-flags/REBOOT_TO_VENDOR_MENU` file so that we don't keep booting to the vendor menu

## Testing

Before merging, will test this manually by editing the code on a non-locked-down production machine