### PR TITLE
Rotate TTY2 screen on VSAP

### DIFF
--- a/config/mark_scan_admin_bash_profile
+++ b/config/mark_scan_admin_bash_profile
@@ -1,0 +1,7 @@
+echo 3 | sudo /usr/bin/tee -a /sys/class/graphics/fbcon/rotate
+export PATH=/vx/code/config/admin-functions:${PATH}
+
+while true; do
+    bash /vx/admin/admin-functions/show-vx-suite-admin-menu.sh
+done
+

--- a/config/sudoers
+++ b/config/sudoers
@@ -31,6 +31,7 @@ vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/create-machine-cert.
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/admin/admin-functions/program-system-administrator-cards.sh
 vx-admin ALL=(root:ALL) NOPASSWD: /usr/local/bin/tpm2-totp
 vx-admin ALL=(root:ALL) NOPASSWD: /usr/sbin/reboot
+vx-admin ALL=(root:ALL) NOPASSWD: /usr/bin/tee
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/code/app-scripts/mount-usb.sh
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/code/app-scripts/unmount-usb.sh
 vx-admin ALL=(root:ALL) NOPASSWD: /vx/code/app-scripts/pactl.sh

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -274,7 +274,11 @@ sudo cp config/dmverity-root.hook /etc/initramfs-tools/hooks/dmverity-root
 sudo cp config/dmverity-root.script /etc/initramfs-tools/scripts/local-premount/dmverity-root
 
 # admin function scripts
-sudo ln -s /vx/code/config/admin_bash_profile /vx/admin/.bash_profile
+if [ "${CHOICE}" = "mark-scan" ]; then
+  sudo ln -s /vx/code/config/mark_scan_admin_bash_profile /vx/admin/.bash_profile
+else
+  sudo ln -s /vx/code/config/admin_bash_profile /vx/admin/.bash_profile
+fi
 sudo ln -s /vx/code/config/admin-functions /vx/admin/admin-functions
 
 # Make sure our cmdline file is readable by vx-admin


### PR DESCRIPTION
For mark-scan images this will rotate the screen in tty2. It takes a second but does work for the machine configuration wizard and after switching to tty2 from the app, although the rotation is not applied until you authenticate the vx-admin user. 

I tested the pieces of this on an image but haven't tested making and using an image E2E with the change applied. Can do if necessary but I was hoping this was safe enough to piggyback on @arsalansufi 's next images. @arsalansufi Feel free to revert if it causes an issue though. 