### PR TITLE
Use dev VotingWorks key to certify QA images + other quality of life improvements

### DIFF
--- a/config/vendor-functions/create-machine-cert.sh
+++ b/config/vendor-functions/create-machine-cert.sh
@@ -81,7 +81,7 @@ read -p "Insert a USB drive into the machine. Press enter once you've done so. "
 echo "Writing cert signing request to USB drive..."
 rm -rf "${USB_DRIVE_CERTS_DIRECTORY}"
 mkdir "${USB_DRIVE_CERTS_DIRECTORY}"
-if [[ ${VX_MACHINE_TYPE} == "admin" ]]; then
+if [[ "${VX_MACHINE_TYPE}" == "admin" ]]; then
     create_machine_cert_signing_request "${machine_jurisdiction}" > "${USB_DRIVE_CERTS_DIRECTORY}/csr.pem"
 else
     create_machine_cert_signing_request > "${USB_DRIVE_CERTS_DIRECTORY}/csr.pem"
@@ -91,10 +91,9 @@ unmount_usb_drive
 
 if [[ "${IS_QA_IMAGE}" == 1 ]]; then
     read -p "Because we're using a QA image, we can auto-certify this machine using the dev VotingWorks private key. You'll be prompted to select a USB drive again. Press enter to continue. "
-    pushd "${VX_FUNCTIONS_ROOT}/../.." > /dev/null
-    VX_PRIVATE_KEY_PATH="./vxsuite/libs/auth/certs/dev/vx-private-key.pem" \
-        ./config/vendor-functions/mock-vx-certifier.sh
-    popd > /dev/null
+    VX_PRIVATE_KEY_PATH="${VX_METADATA_ROOT}/vxsuite/libs/auth/certs/dev/vx-private-key.pem" \
+        VX_METADATA_ROOT="${VX_METADATA_ROOT}" \
+        "${VX_FUNCTIONS_ROOT}/mock-vx-certifier.sh"
     read -p "You'll be prompted to select a USB drive one last time. Press enter to continue. "
 else
     read -p "Remove the USB drive, take it to VxCertifier, and bring it back to this machine when prompted. Press enter once you've re-inserted the USB drive. "

--- a/config/vendor-functions/create-machine-cert.sh
+++ b/config/vendor-functions/create-machine-cert.sh
@@ -118,6 +118,7 @@ unmount_usb_drive
 if ! openssl x509 -in "${MACHINE_CERT_PATH}" -noout -pubkey | \
     diff -q "${VX_CONFIG_ROOT}/key.pub" -; then
     echo -e "\e[31mPublic key in cert doesn't match public key extracted from TPM\e[0m" >&2
+    read -p "Press enter to start over. "
     exit 1
 fi
 

--- a/config/vendor-functions/mock-vx-certifier.sh
+++ b/config/vendor-functions/mock-vx-certifier.sh
@@ -1,19 +1,24 @@
 #!/usr/bin/env bash
 
-# A temporary script to emulate the behavior of VxCertifier, the VotingWorks certification
-# terminal. Should be run from the root of vxsuite-complete-system, with a USB drive plugged in,
-# after create-machine-cert.sh has written a CSR to the USB drive.
+# A script to emulate the behavior of VxCertifier, the VotingWorks certification terminal, with a
+# private key file. Should be run after create-machine-cert.sh has written a CSR to a USB drive.
 #
-# Usage: sudo VX_PRIVATE_KEY_PATH=/path/to/vx-private-key.pem ./config/vendor-functions/mock-vx-certifier.sh
+# Usage: sudo VX_PRIVATE_KEY_PATH=/path/to/vx-private-key.pem /path/to/mock-vx-certifier.sh
 
 set -euo pipefail
+
+: "${VX_FUNCTIONS_ROOT:="$(dirname "${0}")"}"
+# We typically set this to /vx/code, but here we optimize for use in a vxsuite-complete-system dev
+# env, as that's where this is most often used. For auto-certification on QA images, we reset this
+# to /vx/code.
+: "${VX_METADATA_ROOT:="${VX_FUNCTIONS_ROOT}/../.."}"
 
 SERIAL_FILE="/tmp/serial.txt"
 USB_DRIVE_CERTS_DIRECTORY="/media/vx/usb-drive/certs"
 
 rm -f "${SERIAL_FILE}"
 
-VX_METADATA_ROOT="." ./config/vendor-functions/select-usb-drive-and-mount.sh
+VX_METADATA_ROOT="${VX_METADATA_ROOT}" "${VX_FUNCTIONS_ROOT}/select-usb-drive-and-mount.sh"
 
 VX_MACHINE_TYPE="$(< "${USB_DRIVE_CERTS_DIRECTORY}/machine-type")"
 if [[
@@ -29,17 +34,17 @@ fi
 
 if [[ "${VX_MACHINE_TYPE}" = "admin" ]]; then
     openssl x509 -req \
-        -CA ./vxsuite/libs/auth/certs/prod/vx-cert-authority-cert.pem \
+        -CA "${VX_METADATA_ROOT}/vxsuite/libs/auth/certs/prod/vx-cert-authority-cert.pem" \
         -CAkey "${VX_PRIVATE_KEY_PATH}" \
         -CAcreateserial \
         -CAserial "${SERIAL_FILE}" \
         -in "${USB_DRIVE_CERTS_DIRECTORY}/csr.pem" \
         -days 36500 \
-        -extensions v3_ca -extfile ./vxsuite/libs/auth/certs/openssl.cnf \
+        -extensions v3_ca -extfile "${VX_METADATA_ROOT}/vxsuite/libs/auth/certs/openssl.cnf" \
         -out "${USB_DRIVE_CERTS_DIRECTORY}/cert.pem"
 else
     openssl x509 -req \
-        -CA ./vxsuite/libs/auth/certs/prod/vx-cert-authority-cert.pem \
+        -CA "${VX_METADATA_ROOT}/vxsuite/libs/auth/certs/prod/vx-cert-authority-cert.pem" \
         -CAkey "${VX_PRIVATE_KEY_PATH}" \
         -CAcreateserial \
         -CAserial "${SERIAL_FILE}" \
@@ -48,6 +53,6 @@ else
         -out "${USB_DRIVE_CERTS_DIRECTORY}/cert.pem"
 fi
 
-./app-scripts/unmount-usb.sh
+"${VX_METADATA_ROOT}/app-scripts/unmount-usb.sh"
 
 rm "${SERIAL_FILE}"

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -470,6 +470,14 @@ else
     sudo cp config/sudoers /etc/sudoers
 fi
 
+# QA images are certified using the dev VotingWorks private key so root all verification with the
+# dev VotingWorks cert by writing it to the expected file path
+if [[ "${IS_QA_IMAGE}" == 1 ]] ; then
+    sudo cp \
+        /vx/code/vxsuite/libs/auth/certs/dev/vx-cert-authority-cert.pem \
+        /vx/code/vxsuite/libs/auth/certs/prod/vx-cert-authority-cert.pem
+fi
+
 # remove everything from this bootstrap user's home directory
 cd
 rm -rf *


### PR DESCRIPTION
## Core change

We currently have two private-key/public-cert pairs, one for dev and one for prod. The dev key and cert both live in the `vxsuite` repo. The prod cert lives in the `vxsuite` repo, and the prod key is kept secure outside the codebase. The dev key/cert are only used for local dev; the prod key/cert are used for all prod images, including QA images.

This PR makes an update to use the dev key/cert not only for local dev but also for prod QA images, reserving the prod key/cert for final locked-down prod images. The changes to do this are actually super minimal. Conceptually in the vxsuite-complete-system setup-machine.sh script:

```
sudo cp \
    /vx/code/vxsuite/libs/auth/certs/dev/vx-cert-authority-cert.pem \
    /vx/code/vxsuite/libs/auth/certs/prod/vx-cert-authority-cert.pem
```

Plus some changes to the VxCertifier step in the basic configuration wizard. Rather than requiring users to take a USB drive to a separate VxCertifier machine containing the prod key, we can now auto-certify prod QA images using the dev key already in the `vxsuite` repo, a win in and of itself.

This means that cards programmed for local dev will now work on QA images. And the prod key will truly only be used for final images and cards to be sent to customers.

In other words, this PR takes us from:

| Dev key/cert | Prod key/cert |
| :- | :- |
| Local dev | QA images, final images |

To:

| Dev key/cert | Prod key/cert |
| :- | :- |
| Local dev, QA images | Final images |

## Other changes

This PR also makes other quality of life improvements:

- Auto-setting the jurisdiction to vx.test for QA-imaged machines
- Asking for confirmation of the provided jurisdiction before setting it for true prod-imaged machines
- A quick cert correctness check after its copied over from the USB drive

## create-machine-cert.sh sequence for a QA image

I know the repeated USB drive prompts look a bit clunky, but I'm trying to still test as much of the true prod code path as possible when using a QA image. So the branching has been kept minimal and we still use a USB drive for cert creation. You just no longer have to take that USB drive to another computer with access to the prod key.

```
$ sudo VX_CONFIG_ROOT=/home/vx/config VX_METADATA_ROOT=. ./config/vendor-functions/create-machine-cert.sh
Confirm that the machine jurisdiction should be set to: vx.test (y/n) y
Insert a USB drive into the machine. Press enter once you've done so. 

USB drive(s) detected:
0. VxUSB-SKPNT	sdc1	/dev/sdc1	28.9G

Enter the index (0, 1, etc.) of the USB drive that you'd like to use, or press enter to search for USB drives again: 0
Writing cert signing request to USB drive...
Because we're using a QA image, we can auto-certify this machine using the dev VotingWorks private key. You'll be prompted to select a USB drive again. Press enter to continue. 

USB drive(s) detected:
0. VxUSB-SKPNT	sdc1	/dev/sdc1	28.9G

Enter the index (0, 1, etc.) of the USB drive that you'd like to use, or press enter to search for USB drives again: 0
Certificate request self-signature ok
subject=C = US, ST = CA, O = VotingWorks, 1.3.6.1.4.1.59817.1 = admin, 1.3.6.1.4.1.59817.2 = vx.test
You'll be prompted to select a USB drive one last time. Press enter to continue. 

USB drive(s) detected:
0. VxUSB-SKPNT	sdc1	/dev/sdc1	28.9G

Enter the index (0, 1, etc.) of the USB drive that you'd like to use, or press enter to search for USB drives again: 0
Cert found on USB drive!
Copying cert to /home/vx/config/vx-admin-cert-authority-cert.pem...
Machine cert saved! You can remove the USB drive.
```

## Testing

- [x] Tested scripts manually in a vxsuite-complete-system dev env
- [x] Tested scripts manually on an imaged machine with edited files
- [ ] Planning to test this e2e via the next batch of images