### PR TITLE
Add one more correctness check after machine cert creation

### DIFF
--- a/config/vendor-functions/show-vendor-menu.sh
+++ b/config/vendor-functions/show-vendor-menu.sh
@@ -62,7 +62,7 @@ while true; do
     echo -e "Secure Boot State: \e[31mDisabled\e[0m"
     fi
   if [ "${IS_QA_IMAGE}" = "1" ]; then
-    echo -e "QA Image, sudo privileges are enabled."
+    echo -e "QA Image, sudo privileges are enabled, prod VotingWorks cert has been overwritten by dev VotingWorks cert"
   else
     echo -e "Production Image"
   fi


### PR DESCRIPTION
This PR adds one more correctness check after machine cert creation. I recently added a check to make sure that the public key in the machine cert corresponds to the private key in the TPM. I'm now adding one more check to make sure that the machine cert was signed by the correct VotingWorks cert authority.

I felt inspired to make this change after I made a mistake, remotely signing a Pump machine with our dev key instead of our prod key. (They're working with an image before we updated QA images to be signed by the dev key.) This mistake can go missed for a long time. Ballots can even be scanned. An error will only come up when trying to import CVRs from such a machine onto a compatible VxAdmin, as CVR auth will fail.

With these two checks in place, we can have a high degree of confidence that no user errors were made during machine cert creation and the cert dance.

Manually patched a non-locked-down VxAdmin to test this check out.