### PR TITLE
Fix two build errors

### DIFF
--- a/config/vendor-functions/create-machine-cert.sh
+++ b/config/vendor-functions/create-machine-cert.sh
@@ -123,7 +123,7 @@ if ! openssl x509 -in "${MACHINE_CERT_PATH}" -noout -pubkey | \
 fi
 
 # Cert correctness check 2
-if ! openssl verify -CAfile "${VX_METADATA_ROOT}/vxsuite/libs/auth/certs/prod/vx-cert-authority-cert.pem" "${MACHINE_CERT_PATH}"; then
+if ! openssl verify -CAfile "${VX_METADATA_ROOT}/vxsuite/libs/auth/certs/prod/vx-cert-authority-cert.pem" "${MACHINE_CERT_PATH}" > /dev/null; then
     echo -e "\e[31mMachine cert was not signed by the correct cert authority\e[0m" >&2
     read -p "Press enter to start over. "
     exit 1

--- a/config/vendor-functions/hash-signature.sh
+++ b/config/vendor-functions/hash-signature.sh
@@ -20,7 +20,7 @@ if [[ $1 == "noninteractive" ]]; then
   echo "$verity_result"
 else
   echo "$verity_result"
-  read -p "Press enter once you have recorded the image signature."
+  read -p "Press enter once you have recorded the image signature. "
 fi
 
 exit 0;

--- a/config/vendor-functions/program-system-administrator-cards.sh
+++ b/config/vendor-functions/program-system-administrator-cards.sh
@@ -24,7 +24,7 @@ function program_system_administrator_card() {
 service pcscd stop > /dev/null 2>&1
 
 while true; do
-    read -p "Connect a card reader to the machine and insert a card. Press enter to program the card. "
+    read -p "Insert a card into the card reader. Press enter to program the card. "
     if program_system_administrator_card; then # Success case
         while true; do
             read -p "Would you like to program another system administrator card? (y/n) " choice

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -461,7 +461,7 @@ done
 # according to pulseaudio best practices
 vx_ui_homedir=$( getent passwd vx-ui | cut -d: -f6 )
 sudo mkdir -p ${vx_ui_homedir}/.config/pulse
-cat > ${vx_ui_homedir}/.config/pulse/default.pa << 'PULSE'
+sudo tee ${vx_ui_homedir}/.config/pulse/default.pa > /dev/null << 'PULSE'
 .include /etc/pulse/default.pa
 .nofail
 unload-module module-suspend-on-idle


### PR DESCRIPTION
This PR fixes two build errors 🛠️

The first is covered in https://github.com/votingworks/kiosk-browser/pull/169. This PR just pulls that change into `vxsuite-complete-system`.

And the second involves a permissions error when writing to the pulse config file, for preventing muffled sounds:

```
./setup-machine.sh: line 464: /var/vx/ui/.config/pulse/default.pa: Permission denied
```

The current operation `cat > ${vx_ui_homedir}/.config/pulse/default.pa << 'PULSE' ... PULSE` doesn't specify a `sudo` anywhere. And `sudo cat` didn't work in my testing because the `sudo` only applies to the `cat`, not to the redirect `>`. So switched to `sudo tee` instead.

Tested that this works on the build server.