### PR TITLE
Fix pulseaudio permissions

### DIFF
--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -468,6 +468,9 @@ unload-module module-suspend-on-idle
 .fail
 PULSE
 
+# Fix permissions so vx-ui owns the pulseaudio config
+sudo chown -R vx-ui:vx-ui ${vx_ui_homedir}/.config/pulse
+
 echo "Successfully setup machine."
 
 # now we remove permissions, reset passwords, and ready for production.


### PR DESCRIPTION
The `~vx-ui/.config/pulse` directory ended up being owned by `root` rather than the `vx-ui` user. This prevents a symlink being created during pulseaudio initialization that is needed for `vx-ui` and `vx-services` users to access the audio config. This PR fixes that permissions issue.