### PR TITLE
Address various logging quirks

### DIFF
--- a/config/30-votingworks.conf
+++ b/config/30-votingworks.conf
@@ -13,6 +13,7 @@ if $programname == "votingworksapp" and re_match($msg,'^ *\\{.*\\} *$') then /va
 &stop # excludes the messages matched above from being matched by other rules
 # send all other non-json messages from votingworksapp to the main syslog
 if $programname == "votingworksapp" then -/var/log/votingworks/syslog
+&stop # While we have no other cases below that route to syslog, everything goes to syslog by default so stop to prevent a double log
 
 template(name="usbDeviceInformation" type="list" option.jsonf="on") {
     property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")

--- a/config/30-votingworks.conf
+++ b/config/30-votingworks.conf
@@ -1,12 +1,12 @@
 template(name="jsonfmt" type="list") {
-         constant(value="{")
-         property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")
-         constant(value=",")
-         property(outname="host" name="hostname" format="jsonf")
-         constant(value=",")
-         property(outname="message" name="msg" position.from="2")
-         constant(value="\n")
- }
+    constant(value="{")
+    property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")
+    constant(value=",")
+    property(outname="host" name="hostname" format="jsonf")
+    constant(value=",")
+    property(outname="message" name="msg" position.from="2")
+    constant(value="\n")
+}
 
 # reformat json messages into one json blob and send to vx-logs.log
 if $programname == "votingworksapp" and re_match($msg,'^ *\\{.*\\} *$') then /var/log/votingworks/vx-logs.log;jsonfmt
@@ -15,15 +15,15 @@ if $programname == "votingworksapp" and re_match($msg,'^ *\\{.*\\} *$') then /va
 if $programname == "votingworksapp" then -/var/log/votingworks/syslog
 
 template(name="usbDeviceInformation" type="list" option.jsonf="on") {
-         property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")
-         property(outname="host" name="hostname" format="jsonf")
-         property(outname="message" name="msg" format="jsonf")
-         constant(outname="source" value="system" format="jsonf")
-         constant(outname="eventId" value="usb-device-change-detected" format="jsonf")
-         constant(outname="eventType" value="system-status" format="jsonf")
-         constant(outname="user" value="system" format="jsonf")
-         constant(outname="disposition" value="na" format="jsonf")
- }
+    property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")
+    property(outname="host" name="hostname" format="jsonf")
+    property(outname="message" name="msg" format="jsonf")
+    constant(outname="source" value="system" format="jsonf")
+    constant(outname="eventId" value="usb-device-change-detected" format="jsonf")
+    constant(outname="eventType" value="system-status" format="jsonf")
+    constant(outname="user" value="system" format="jsonf")
+    constant(outname="disposition" value="na" format="jsonf")
+}
 
 if $programname == "kernel" and ($msg startsWith "usb") then /var/log/votingworks/vx-logs.log;usbDeviceInformation
 
@@ -31,93 +31,92 @@ if $programname == "kernel" and ($msg startsWith "usb") then /var/log/votingwork
 
 ## Route logs for machine boot
 template(name="machineBootInit" type="list" option.jsonf="on") {
-         property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")
-         property(outname="host" name="hostname" format="jsonf")
-         constant(outname="source" value="system" format="jsonf")
-         constant(outname="eventId" value="machine-boot-init" format="jsonf")
-         constant(outname="eventType" value="system-action" format="jsonf")
-         constant(outname="user" value="system" format="jsonf")
-         constant(outname="disposition" value="na" format="jsonf")
-         constant(outname="message" value="Machine boot initiated" format="jsonf")
- }
+    property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")
+    property(outname="host" name="hostname" format="jsonf")
+    constant(outname="source" value="system" format="jsonf")
+    constant(outname="eventId" value="machine-boot-init" format="jsonf")
+    constant(outname="eventType" value="system-action" format="jsonf")
+    constant(outname="user" value="system" format="jsonf")
+    constant(outname="disposition" value="na" format="jsonf")
+    constant(outname="message" value="Machine boot initiated" format="jsonf")
+}
 template(name="machineBootSuccess" type="list" option.jsonf="on") {
-         property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")
-         property(outname="host" name="hostname" format="jsonf")
-         constant(outname="source" value="system" format="jsonf")
-         constant(outname="eventId" value="machine-boot-complete" format="jsonf")
-         constant(outname="eventType" value="system-status" format="jsonf")
-         constant(outname="user" value="system" format="jsonf")
-         constant(outname="disposition" value="success" format="jsonf")
-         property(outname="message" name="msg" format="jsonf")
- }
+    property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")
+    property(outname="host" name="hostname" format="jsonf")
+    constant(outname="source" value="system" format="jsonf")
+    constant(outname="eventId" value="machine-boot-complete" format="jsonf")
+    constant(outname="eventType" value="system-status" format="jsonf")
+    constant(outname="user" value="system" format="jsonf")
+    constant(outname="disposition" value="success" format="jsonf")
+    property(outname="message" name="msg" format="jsonf")
+}
 
 if $programname == "kernel" and $msg startswith "Command line: BOOT_IMAGE" then /var/log/votingworks/vx-logs.log;machineBootInit
 if $syslogtag == "systemd[1]:" and $msg contains "Startup finished" then /var/log/votingworks/vx-logs.log;machineBootSuccess
 
 ## Route logs for machine shutdown
 template(name="machineShutdownInit" type="list" option.jsonf="on") {
-         property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")
-         property(outname="host" name="hostname" format="jsonf")
-         constant(outname="source" value="system" format="jsonf")
-         constant(outname="eventId" value="machine-shutdown-init" format="jsonf")
-         constant(outname="eventType" value="system-action" format="jsonf")
-         constant(outname="user" value="system" format="jsonf")
-         constant(outname="disposition" value="na" format="jsonf")
-         property(outname="message" name="msg" format="jsonf")
- }
+    property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")
+    property(outname="host" name="hostname" format="jsonf")
+    constant(outname="source" value="system" format="jsonf")
+    constant(outname="eventId" value="machine-shutdown-init" format="jsonf")
+    constant(outname="eventType" value="system-action" format="jsonf")
+    constant(outname="user" value="system" format="jsonf")
+    constant(outname="disposition" value="na" format="jsonf")
+    property(outname="message" name="msg" format="jsonf")
+}
 template(name="machineShutdownSuccess" type="list" option.jsonf="on") {
-         property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")
-         property(outname="host" name="hostname" format="jsonf")
-         constant(outname="source" value="system" format="jsonf")
-         constant(outname="eventId" value="machine-shutdown-complete" format="jsonf")
-         constant(outname="eventType" value="system-status" format="jsonf")
-         constant(outname="user" value="system" format="jsonf")
-         constant(outname="disposition" value="success" format="jsonf")
-         property(outname="message" name="msg" format="jsonf")
- }
+    property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")
+    property(outname="host" name="hostname" format="jsonf")
+    constant(outname="source" value="system" format="jsonf")
+    constant(outname="eventId" value="machine-shutdown-complete" format="jsonf")
+    constant(outname="eventType" value="system-status" format="jsonf")
+    constant(outname="user" value="system" format="jsonf")
+    constant(outname="disposition" value="success" format="jsonf")
+    property(outname="message" name="msg" format="jsonf")
+}
 
 if $programname == "systemd-logind" and ($msg contains "System is rebooting" or $msg contains "System is powering down") then /var/log/votingworks/vx-logs.log;machineShutdownInit
 if $syslogtag == "systemd[1]:" and $msg contains "Shutting down" then /var/log/votingworks/vx-logs.log;machineShutdownSuccess
 
 ## Sudo actions
 template(name="sudoAction" type="list" option.jsonf="on") {
-         property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")
-         property(outname="host" name="hostname" format="jsonf")
-         constant(outname="source" value="system" format="jsonf")
-         constant(outname="eventId" value="sudo-action" format="jsonf")
-         constant(outname="eventType" value="user-action" format="jsonf")
-         constant(outname="user" value="system" format="jsonf")
-         constant(outname="disposition" value="na" format="jsonf")
-         property(outname="message" name="msg" format="jsonf")
+    property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")
+    property(outname="host" name="hostname" format="jsonf")
+    constant(outname="source" value="system" format="jsonf")
+    constant(outname="eventId" value="sudo-action" format="jsonf")
+    constant(outname="eventType" value="user-action" format="jsonf")
+    constant(outname="user" value="system" format="jsonf")
+    constant(outname="disposition" value="na" format="jsonf")
+    property(outname="message" name="msg" format="jsonf")
 }
 
 if $syslogtag contains "sudo" then /var/log/votingworks/vx-logs.log;sudoAction
 
 ## Password changes
 template(name="passwdChange" type="list" option.jsonf="on") {
-         property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")
-         property(outname="host" name="hostname" format="jsonf")
-         constant(outname="source" value="system" format="jsonf")
-         constant(outname="eventId" value="password-change" format="jsonf")
-         constant(outname="eventType" value="user-action" format="jsonf")
-         constant(outname="user" value="system" format="jsonf")
-         constant(outname="disposition" value="success" format="jsonf")
-         property(outname="message" name="msg" format="jsonf")
+    property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")
+    property(outname="host" name="hostname" format="jsonf")
+    constant(outname="source" value="system" format="jsonf")
+    constant(outname="eventId" value="password-change" format="jsonf")
+    constant(outname="eventType" value="user-action" format="jsonf")
+    constant(outname="user" value="system" format="jsonf")
+    constant(outname="disposition" value="success" format="jsonf")
+    property(outname="message" name="msg" format="jsonf")
 }
 
 if $syslogtag contains "passwd" then /var/log/votingworks/vx-logs.log;passwdChange
 
 ## dm-verity boot logs
 template(name="dmverityBoot" type="list" option.jsonf="on") {
-         property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")
-         property(outname="host" name="hostname" format="jsonf")
-         constant(outname="source" value="system" format="jsonf")
-         constant(outname="eventId" value="dmverity-boot" format="jsonf")
-         constant(outname="eventType" value="system-status" format="jsonf")
-         constant(outname="user" value="system" format="jsonf")
-         constant(outname="disposition" value="success" format="jsonf")
-         property(outname="message" name="msg" format="jsonf")
+    property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")
+    property(outname="host" name="hostname" format="jsonf")
+    constant(outname="source" value="system" format="jsonf")
+    constant(outname="eventId" value="dmverity-boot" format="jsonf")
+    constant(outname="eventType" value="system-status" format="jsonf")
+    constant(outname="user" value="system" format="jsonf")
+    constant(outname="disposition" value="success" format="jsonf")
+    property(outname="message" name="msg" format="jsonf")
 }
 
 if $msg contains "verity" then /var/log/votingworks/vx-logs.log;dmverityBoot
-

--- a/config/rsyslog.conf
+++ b/config/rsyslog.conf
@@ -38,8 +38,10 @@ module(load="imklog" permitnonkernelfacility="on")
 #
 $ActionFileDefaultTemplate RSYSLOG_TraditionalFileFormat
 
-# Filter duplicated messages
-$RepeatedMsgReduction on
+# This coalesces repeated messages and can result in our vx-logs.log log matching rule failing to
+# match logs that should be matched. Rather than updating our log matching rule, we simply turn
+# this setting off since the space savings from it are negligible.
+$RepeatedMsgReduction off
 
 #
 # Set the default permissions for all log files.

--- a/run-scripts/run-admin.sh
+++ b/run-scripts/run-admin.sh
@@ -17,4 +17,4 @@ fi
 
 export PIPENV_VENV_IN_PROJECT=1
 export NODE_ENV=production
-(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/admin/backend run & make -C vxsuite/services/converter-ms-sems run & make -C vxsuite/apps/admin/frontend run) | logger --tag votingworksapp
+(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/admin/backend run & make -C vxsuite/services/converter-ms-sems run & make -C vxsuite/apps/admin/frontend run) | logger -S 4096 --tag votingworksapp

--- a/run-scripts/run-central-scan.sh
+++ b/run-scripts/run-central-scan.sh
@@ -17,4 +17,4 @@ fi
 
 export PIPENV_VENV_IN_PROJECT=1
 export NODE_ENV=production
-(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/central-scan/backend run & make -C vxsuite/apps/central-scan/frontend run) | logger --tag votingworksapp
+(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/central-scan/backend run & make -C vxsuite/apps/central-scan/frontend run) | logger -S 4096 --tag votingworksapp

--- a/run-scripts/run-kiosk-browser-forever-and-log.sh
+++ b/run-scripts/run-kiosk-browser-forever-and-log.sh
@@ -35,4 +35,4 @@ fi
 while true; do
     echo "starting kiosk-browser"
     ./run-kiosk-browser.sh http://localhost:3000/
-done 2>&1 | logger --tag votingworksapp
+done 2>&1 | logger -S 4096 --tag votingworksapp

--- a/run-scripts/run-mark-scan-controller-daemon.sh
+++ b/run-scripts/run-mark-scan-controller-daemon.sh
@@ -10,4 +10,4 @@ CONFIG=${VX_CONFIG_ROOT:-./config}
 METADATA=${VX_METADATA_ROOT:-./}
 source ${CONFIG}/read-vx-machine-config.sh
 
-(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/mark-scan/accessible-controller run) | logger --tag votingworksapp
+(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/mark-scan/accessible-controller run) | logger -S 4096 --tag votingworksapp

--- a/run-scripts/run-mark-scan-fai-100-daemon.sh
+++ b/run-scripts/run-mark-scan-fai-100-daemon.sh
@@ -10,4 +10,4 @@ CONFIG=${VX_CONFIG_ROOT:-./config}
 METADATA=${VX_METADATA_ROOT:-./}
 source ${CONFIG}/read-vx-machine-config.sh
 
-(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/mark-scan/fai-100-controller run) | logger --tag votingworksapp
+(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/mark-scan/fai-100-controller run) | logger -S 4096 --tag votingworksapp

--- a/run-scripts/run-mark-scan-pat-daemon.sh
+++ b/run-scripts/run-mark-scan-pat-daemon.sh
@@ -10,4 +10,4 @@ CONFIG=${VX_CONFIG_ROOT:-./config}
 METADATA=${VX_METADATA_ROOT:-./}
 source ${CONFIG}/read-vx-machine-config.sh
 
-(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/mark-scan/pat-device-input run) | logger --tag votingworksapp
+(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/mark-scan/pat-device-input run) | logger -S 4096 --tag votingworksapp

--- a/run-scripts/run-mark-scan.sh
+++ b/run-scripts/run-mark-scan.sh
@@ -12,4 +12,4 @@ source ${CONFIG}/read-vx-machine-config.sh
 
 export PIPENV_VENV_IN_PROJECT=1
 export NODE_ENV=production
-(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/mark-scan/backend run & make -C vxsuite/apps/mark-scan/frontend run) | logger --tag votingworksapp
+(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/mark-scan/backend run & make -C vxsuite/apps/mark-scan/frontend run) | logger -S 4096 --tag votingworksapp

--- a/run-scripts/run-mark.sh
+++ b/run-scripts/run-mark.sh
@@ -12,4 +12,4 @@ source ${CONFIG}/read-vx-machine-config.sh
 
 export PIPENV_VENV_IN_PROJECT=1
 export NODE_ENV=production
-(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/mark/backend run & make -C vxsuite/apps/mark/frontend run) | logger --tag votingworksapp
+(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/mark/backend run & make -C vxsuite/apps/mark/frontend run) | logger -S 4096 --tag votingworksapp

--- a/run-scripts/run-scan.sh
+++ b/run-scripts/run-scan.sh
@@ -17,4 +17,4 @@ fi
 
 export PIPENV_VENV_IN_PROJECT=1
 export NODE_ENV=production
-(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/scan/backend run & make -C vxsuite/apps/scan/frontend run) | logger --tag votingworksapp
+(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/scan/backend run & make -C vxsuite/apps/scan/frontend run) | logger -S 4096 --tag votingworksapp

--- a/run.sh
+++ b/run.sh
@@ -77,7 +77,7 @@ if [[ " ${ALL_APPS[@]} " =~ " ${APP} " ]]; then
     trap 'kill 0' SIGINT SIGHUP; "./run-${APP}.sh" &
     # Delay kiosk-browser to make sure the app is running first
     (while ! curl -s localhost:3000; do sleep 1; done; "./run-kiosk-browser.sh"; kill 0)
-  ) 2>&1 | logger --tag votingworksapp
+  ) 2>&1 | logger -S 4096 --tag votingworksapp
 elif [[ "${APP}" = -h || "${APP}" = --help ]]; then
   usage
   exit 0


### PR DESCRIPTION
_Reviewing by commit recommended_

## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/5595

There's long been a sense on the software team that something is off about logs in prod, e.g., logs that we go looking for seem missing, some logs are double-logged, etc. This PR should address at least a few of those logging quirks.

First, it disables repeated message reduction, which can interfere with log matching rules. We detect `vx-logs.log` logs, for example, by looking for logs that start and end with a curly brace, indicating JSON. But repeated message reduction adds a `message repeated N times: ` prefix that throws that matching off.

Second, this PR increases the log size limit before splitting from the 1KiB default to 4KiB. When a log is split across multiple lines, log matching rules can once again fail to match logs that should otherwise be matched. This [Linux logger manual](https://man7.org/linux/man-pages/man1/logger.1.html) indicates that 4KiB should be safe for most systems, though I did test sendings logs of that size on a QA-imaged machine just to be sure. Of course, a log may still exceed that length, but that's pretty edge-case-y. The split logs will still make it to the syslog in that case.

Finally, this PR stops double logging certain logs to the syslog file, which I think all of us have seen at some point or another. Easy fix there.

## Testing

As alluded to above, all of these changes have been tested on a QA-imaged machine