### PR TITLE
Decrease vendor menu font size so everything fits

### DIFF
--- a/config/vendor-functions/show-vendor-menu.sh
+++ b/config/vendor-functions/show-vendor-menu.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-setfont /usr/share/consolefonts/Lat7-Terminus32x16.psf.gz 
+setfont /usr/share/consolefonts/Lat7-Terminus24x12.psf.gz
 
 set -euo pipefail
 


### PR DESCRIPTION
## Overview

While testing vendor cards, I realized that the vendor menu is cut off at its current font size. And the menu can't be scrolled so some content is fully inaccessible. This PR decreases the font size so that everything fits.

| | Before | After |
| - | - | - |
| VxAdmin | ![vx-admin-before](https://github.com/user-attachments/assets/18702b55-761d-4c94-8fe7-b2006ad03867) | ![vx-admin-after](https://github.com/user-attachments/assets/17b5883d-d61d-4f38-af7f-bd4386f467d8) |
| VxScan | ![vx-scan-before](https://github.com/user-attachments/assets/ca4d2b9e-bb9d-4b08-a638-0ed4e99f1e30) | ![vx-scan-after](https://github.com/user-attachments/assets/e50328ea-9270-4764-9f11-ba5636ccebe0) |




