### PR TITLE
Outwardly refer to VxMarkScan as VxMark and remove VxMark(Old) as option

### DIFF
--- a/config/vendor-functions/show-vendor-menu.sh
+++ b/config/vendor-functions/show-vendor-menu.sh
@@ -108,9 +108,6 @@ while true; do
   echo "${#CHOICES[@]}. Recreate Machine Cert"
   CHOICES+=('recreate-machine-cert')
 
-  echo "${#CHOICES[@]}. Reset System Authentication Code"
-  CHOICES+=('reset-totp')
-
   echo "${#CHOICES[@]}. Setup Boot Entry"
   CHOICES+=('setup-boot-entry')
 
@@ -240,11 +237,6 @@ while true; do
     program-system-administrator-cards)
       sudo "${VX_FUNCTIONS_ROOT}/program-system-administrator-cards.sh"
       prompt-to-restart
-    ;;
-    
-    reset-totp)
-      "${VX_FUNCTIONS_ROOT}/reset-totp.sh"
-      read -s -n 1
     ;;
     
     lockdown)

--- a/config/vendor-functions/show-vendor-menu.sh
+++ b/config/vendor-functions/show-vendor-menu.sh
@@ -252,8 +252,8 @@ while true; do
       read -s -n 1
     ;;
 
-    hash-signature)
-      sudo "${VX_FUNCTIONS_ROOT}/hash-signature.sh"
+    show-system-hash)
+      sudo "${VX_FUNCTIONS_ROOT}/show-system-hash.sh"
     ;;
     
     setup-boot-entry)

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -28,12 +28,8 @@ CHOICES+=('central-scan')
 MODEL_NAMES+=('VxCentralScan')
 
 echo "${#CHOICES[@]}. VxMark"
-CHOICES+=('mark')
+CHOICES+=('mark-scan') # TODO: Transition this to "mark" once we've decided what to do about VxMark(Old)
 MODEL_NAMES+=('VxMark')
-
-echo "${#CHOICES[@]}. VxMarkScan"
-CHOICES+=('mark-scan')
-MODEL_NAMES+=('VxMarkScan')
 
 echo "${#CHOICES[@]}. VxScan"
 CHOICES+=('scan')


### PR DESCRIPTION
Issue link: https://github.com/votingworks/vxsuite/issues/5588

Quite a while back, we decided to rename VxMarkScan VxMark and now think of the v2 VxMark deployed in Mississippi as VxMark(Old). We'll eventually come up with a better naming scheme and more fully rename things in code.

But before we submit v4 for cert, let's at least remove VxMark(Old) as an option in the `setup-machine.sh` script and outwardly refer to VxMarkScan as VxMark.

This will hopefully avoid some confusion during SLI Trusted Build.