### PR TITLE
Ensure that var partition expansion happens on real hardware and not accidentally on the build VM

### DIFF
--- a/config/vendor-functions/expand-var-filesystem.sh
+++ b/config/vendor-functions/expand-var-filesystem.sh
@@ -2,14 +2,6 @@
 
 set -euo pipefail
 
-# Using a flag file to skip resize operations if already completed
-# There's not an issue running these commands again, but this saves time
-flag_file="/home/VAR_RESIZED"
-
-if [[ -f ${flag_file} ]]; then
-  exit 0
-fi
-
 # Find the mapped device for /var, need this to look up the LV later
 var_map=$( df -l /var | grep mapper | awk '{print $1}' )
 
@@ -41,7 +33,6 @@ LVM_SYSTEM_DIR=/home/.lvm pvresize $pvs_path
 # and it has no effect on systems not using encrypted /var
 if [[ $volume_to_extend != "NONE" ]]; then
   echo "insecure" | LVM_SYSTEM_DIR=/home/.lvm lvextend -r -l +100%FREE ${volume_to_extend}
-  touch ${flag_file}
 fi
 
 exit 0;

--- a/config/vendor-functions/show-vendor-menu.sh
+++ b/config/vendor-functions/show-vendor-menu.sh
@@ -12,13 +12,8 @@ if [[ $(tty) = /dev/tty1 ]] && [[ -f "/home/REKEY_VIA_TPM" ]]; then
   sudo "${VX_FUNCTIONS_ROOT}/rekey-via-tpm.sh"
 fi
 
-# We do this after the rekey operation to save time. It's much faster to encrypt /var
-# before we expand it to the max available storage.
-if [[ $(tty) = /dev/tty1 ]]; then
-  sudo "${VX_FUNCTIONS_ROOT}/expand-var-filesystem.sh"
-fi
-
 if [[ $(tty) = /dev/tty1 ]] && [[ -f "${VX_CONFIG_ROOT}/RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT" ]]; then
+  sudo "${VX_FUNCTIONS_ROOT}/expand-var-filesystem.sh"
   "${VX_FUNCTIONS_ROOT}/basic-configuration.sh"
   exit 0
 fi


### PR DESCRIPTION
## Overview

Issue link: https://github.com/votingworks/vxsuite/issues/5592

We've been finding that var partition expansion isn't always happening on machines after imaging. Our current theory is that the expansion is accidentally happening on the build VM, which sets a flag indicating that expansion has been taken care of and then prevents it from happening on actual machines.

My inclination is that, instead of using a file flag to mark the operation complete (`VAR_EXPANDED`), we should use a file flag to indicate that the operation needs to be done (`EXPAND_VAR`). This is how all of our other file flags work.

But instead of creating a new flag for this purpose, which we'll need to remember to set, I figured we could just use the existing `RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT` flag. That flag is nice because we already make sure to set it (there's even a check that it's been set in the lockdown script). And conceptually, this operation does fit under the bucket of "configuration" that only needs to happen on first boot.

## Testing

- [ ] Working on testing this manually