### PR TITLE
Handle slight clock divergences between machines during machine cert check in basic config wizard

### DIFF
--- a/config/vendor-functions/create-machine-cert.sh
+++ b/config/vendor-functions/create-machine-cert.sh
@@ -123,8 +123,12 @@ if ! openssl x509 -in "${MACHINE_CERT_PATH}" -noout -pubkey | \
 fi
 
 # Cert correctness check 2
-if ! openssl verify -CAfile "${VX_METADATA_ROOT}/vxsuite/libs/auth/certs/prod/vx-cert-authority-cert.pem" "${MACHINE_CERT_PATH}" > /dev/null; then
-    echo -e "\e[31mMachine cert was not signed by the correct cert authority\e[0m" >&2
+if ! openssl verify \
+    # Accept a cert that has a start time slightly in the future because the clock on VxCertifier
+    # was slightly ahead of the machine clock
+    -attime "$(date -d "+10 minutes" +%s)" \
+    -CAfile "${VX_METADATA_ROOT}/vxsuite/libs/auth/certs/prod/vx-cert-authority-cert.pem" "${MACHINE_CERT_PATH}" > /dev/null; then
+    echo -e "\e[31mMachine cert was not signed by the correct cert authority or is not yet valid because of a clock mismatch\e[0m" >&2
     read -p "Press enter to start over. "
     exit 1
 fi

--- a/config/vendor-functions/lockdown.sh
+++ b/config/vendor-functions/lockdown.sh
@@ -136,7 +136,7 @@ fi
 
 # Output the dm-verity hash
 echo "Hash: ${HASH}"
-read -p "Press enter once you have recorded the system hash."
+read -p "Press enter once you have recorded the system hash. "
 
 # Shut down the locked down system
 # We can't reboot this on the aws build machine due to encrypted /var


### PR DESCRIPTION
Issue links: https://github.com/votingworks/vxsuite/issues/3796, https://github.com/votingworks/vxsuite/issues/5616

The vxsuite-complete-system equivalent of https://github.com/votingworks/vxsuite/pull/5621. Now that we perform a check of the created machine cert at the end of the basic config wizard, the same clock issue that can affect card verification can now affect machine cert verification.

The situation here is specifically as follows:
1. A machine cert is created on VxCertifier.
2. That machine cert is immediately taken to the machine, and a message appears indicating that the cert isn't valid (and in fact misleadingly suggests that the cert wasn't signed by the correct CA).

If you wait just a minute or so between steps 1 and 2, no issue.

The issue here is that VxCetrifier has a time slightly ahead of the machine, so the machine cert start date is in the future when the cert is taken to the machine. Only if the machine clock has caught up to the cert start date will the cert be accepted.

This of course seems surprising because we're setting the clock just before this step, so the clock should be correct. But it's really just a matter of the seconds, e.g., you set 1:30pm, which sets the clock to 1:30pm 00s, but it's actually 1:30pm 54s, right now.

For the case that the clocks really are significantly out of sync, I've augmented the error message to mention clock mismatches.


