### PR TITLE
Reduce boot messages and final size of VM

### DIFF
--- a/config/autologin.sh
+++ b/config/autologin.sh
@@ -10,4 +10,4 @@ else
 fi
 # For the getty service, you can't have any nested processes, thus we use exec to
 # make mingetty take over the process of this script.
-exec /sbin/mingetty --autologin $USER --noclear $1
+exec /sbin/mingetty --noissue --autologin $USER --noclear $1

--- a/config/ui_bash_profile
+++ b/config/ui_bash_profile
@@ -1,7 +1,7 @@
 export PATH=/vx/code/config/vendor-functions:${PATH}
 
 if [[ $(tty) = /dev/tty1 ]]; then
-   exec startx
+   exec startx > /tmp/vx-ui-startx.log 2>&1
 fi
 
 export PATH=$PATH:/sbin

--- a/config/vm-fstrim.service
+++ b/config/vm-fstrim.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=Run fstrim once after setup-machine initiates a reboot/shutdown
+DefaultDependencies=no
+Before=shutdown.target reboot.target umount.target
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c '/sbin/fstrim -av && systemctl disable vm-fstrim.service'
+RemainAfterExit=yes
+
+[Install]
+WantedBy=shutdown.target reboot.target

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -525,6 +525,10 @@ if [[ "${IS_QA_IMAGE}" == 1 ]] ; then
         /vx/code/vxsuite/libs/auth/certs/prod/vx-cert-authority-cert.pem
 fi
 
+# Set up a one-time run of fstrim to reduce VM size
+sudo cp config/vm-fstrim.service /etc/systemd/system/
+sudo systemctl enable vm-fstrim.service
+
 # copy in our sudoers file, which removes sudo privileges except for very specific circumstances
 # where needed
 # NOTE: you cannot use sudo commands after this runs
@@ -540,13 +544,6 @@ fi
 cd
 rm -rf *
 rm -rf .*
-
-# see if we can reclaim disk space from cache after home directory deletions
-/usr/bin/sync
-cd /tmp
-ls
-cd
-ls -altr
 
 echo "Machine setup is complete. Please wait for the VM to reboot."
 

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -455,6 +455,15 @@ if [[ "${CHOICE}" == "mark-scan" ]]; then
   done
 fi
 
+# To provide a boot sequence with as few console logs as possible
+# we suppress the messages from the login command
+for user in vx-vendor vx-ui
+do
+  user_home_dir=$( getent passwd "${user}" | cut -d: -f6 )
+  sudo touch ${user_home_dir}/.hushlogin
+  sudo chown ${user}:${user} ${user_home_dir}/.hushlogin
+done
+
 # We need to disable pulseaudio for users since it runs per user
 # We manually start the pulseaudio service within vxsuite for the vx-ui user
 # Note: Depending on future use-cases, we may need to disable pulseaudio 


### PR DESCRIPTION
This PR suppresses or redirects various boot sequence output via easily available options. In the future, we will further streamline the boot sequence via hardware-specific settings and a consistent boot logo experience.

This PR also includes a one-time use of the `fstrim` tool to reclaim disk space within a VM after `setup-machine` initiates a reboot or shutdown of the system. This results in a significant reduction in the size of our final images, making transferring them to/from S3 and USB drives much faster. 