### PR TITLE
suppress non-critical kernel boot messages in a locked down image

### DIFF
--- a/config/cmdline
+++ b/config/cmdline
@@ -1,1 +1,1 @@
-root=/dev/mapper/vroot ro quiet vt.handoff=7 fsck.mode=skip panic=3 verity.error_behavior=restart verity.hashdev=/dev/mapper/Vx--vg-hashes verity.rootdev=/dev/mapper/Vx--vg-root verity.hash=
+root=/dev/mapper/vroot ro quiet loglevel=3 vt.handoff=7 fsck.mode=skip panic=3 verity.error_behavior=restart verity.hashdev=/dev/mapper/Vx--vg-hashes verity.rootdev=/dev/mapper/Vx--vg-root verity.hash=


### PR DESCRIPTION
It's a bit of a hammer, but this will remove non-critical boot messages in a locked down image. We should still implement a better splash screen solution that works for all our hardware options, but this improves the overall boot experience.