### PR TITLE
add custom interfaces file

### DIFF
--- a/config/interfaces
+++ b/config/interfaces
@@ -1,0 +1,5 @@
+# This only allows the loopback device to be configured automatically
+
+# The loopback network interface
+auto lo
+iface lo inet loopback

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -435,6 +435,9 @@ sudo rm -rf /lib/modules/*/kernel/drivers/net/*
 # delete any remembered existing network connections (e.g. wifi passwords)
 sudo rm -f /etc/NetworkManager/system-connections/*
 
+# replace /etc/network/interfaces to only allow loopback on future boots
+sudo cp config/interfaces /etc/network/interfaces
+
 # set up the service for the selected machine type
 sudo cp config/${CHOICE}.service /etc/systemd/system/
 sudo chmod 644 /etc/systemd/system/${CHOICE}.service


### PR DESCRIPTION
During the build phase, VMs have a network interface automatically configured. Although that interface is not active on production systems, it can cause shutdown to take extra time on some systems, most notably vxscan. This PR explicitly replaces the `/etc/network/interfaces` file with one that only defines the `loopback` interface.