### PR TITLE
Correct a file name that recently changed

### DIFF
--- a/config/vendor-functions/create-machine-cert.sh
+++ b/config/vendor-functions/create-machine-cert.sh
@@ -93,7 +93,7 @@ if [[ "${IS_QA_IMAGE}" == 1 ]]; then
     read -p "Because we're using a QA image, and the production VotingWorks cert has been overwritten by the dev VotingWorks cert, we can auto-certify this machine using the dev VotingWorks private key. You'll be prompted to select a USB drive again. Press enter to continue. "
     VX_PRIVATE_KEY_PATH="${VX_METADATA_ROOT}/vxsuite/libs/auth/certs/dev/vx-private-key.pem" \
         VX_METADATA_ROOT="${VX_METADATA_ROOT}" \
-        "${VX_FUNCTIONS_ROOT}/mock-vx-certifier.sh"
+        "${VX_FUNCTIONS_ROOT}/vx-certifier.sh"
     read -p "You'll be prompted to select a USB drive one last time. Press enter to continue. "
 else
     read -p "Remove the USB drive, take it to VxCertifier, and bring it back to this machine when prompted. Press enter once you've re-inserted the USB drive. "


### PR DESCRIPTION
Updated a file name in https://github.com/votingworks/vxsuite-complete-system/pull/431 and forgot to update a reference. This is currently causing the basic config wizard for QA images to fail