### PR TITLE
Automate re-encrypting /var via TPM

### DIFF
--- a/config/vendor-functions/expand-var-filesystem.sh
+++ b/config/vendor-functions/expand-var-filesystem.sh
@@ -29,10 +29,10 @@ growpart "/dev/${parent_partition}" 3 || true
 LVM_SYSTEM_DIR=/home/.lvm pvresize $pvs_path
 
 # This extends the logical volume to the max available space (as created by the previous
-# commands). We pass along the "insecure" passphrase for systems using encrypted /var,
+# commands). We pass along the empty passphrase for systems using encrypted /var,
 # and it has no effect on systems not using encrypted /var
 if [[ $volume_to_extend != "NONE" ]]; then
-  echo "insecure" | LVM_SYSTEM_DIR=/home/.lvm lvextend -r -l +100%FREE ${volume_to_extend}
+  echo "" | LVM_SYSTEM_DIR=/home/.lvm lvextend -r -l +100%FREE ${volume_to_extend}
 fi
 
 exit 0;

--- a/config/vendor-functions/lockdown.sh
+++ b/config/vendor-functions/lockdown.sh
@@ -74,7 +74,7 @@ fi
 # Only do this if the crypttab is already configured, just in case
 if grep '^var_decrypted' /etc/crypttab > /dev/null; then
   sed -i -e /^var_decrypted/d /etc/crypttab
-  echo "var_decrypted /dev/Vx-vg/var_encrypted none luks,tpm2-device=auto" >> /etc/crypttab
+  echo "var_decrypted /dev/Vx-vg/var_encrypted none try-empty-password,luks,tpm2-device=auto" >> /etc/crypttab
   touch /home/REKEY_VIA_TPM
 fi
 


### PR DESCRIPTION
This PR builds on https://github.com/votingworks/vxsuite-build-system/pull/153 to remove the manual entry of the "insecure" password on signed images when re-encrypting the `/var` partition via the TPM. We can use an empty password for the initial decryption, then encrypt via TPM as before, and finally remove the empty password as a decryption method.