### PR TITLE
Update the /var expansion process in support of updating vx-iso functionality

### DIFF
--- a/config/autologin.sh
+++ b/config/autologin.sh
@@ -3,7 +3,7 @@
 # This script is designed to be run in override.conf file for the service getty@tty1.
 # It conditionally selects which user to automatically log in as, based on whether or not the
 # machine 1) needs configuration or 2) is being rebooted into the vendor menu.
-if [[ -f /vx/config/RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT ]] || [[ -f /vx/config/app-flags/REBOOT_TO_VENDOR_MENU ]]; then
+if [[ -f /vx/config/EXPAND_VAR ]] || [[ -f /vx/config/RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT ]] || [[ -f /vx/config/app-flags/REBOOT_TO_VENDOR_MENU ]]; then
     USER=vx-vendor
 else
     USER=vx-ui

--- a/config/vendor-functions/expand-var-filesystem.sh
+++ b/config/vendor-functions/expand-var-filesystem.sh
@@ -35,8 +35,8 @@ if [[ $volume_to_extend != "NONE" ]]; then
   echo "" | LVM_SYSTEM_DIR=/home/.lvm lvextend -r -l +100%FREE ${volume_to_extend}
 fi
 
-if [[ -f "${VX_CONFIG_ROOT}/EXPAND_VAR" ]]; then
-  rm -f "${VX_CONFIG_ROOT}/EXPAND_VAR"
+if [[ -f "/vx/config/EXPAND_VAR" ]]; then
+  rm -f "/vx/config/EXPAND_VAR"
 fi
 
 exit 0;

--- a/config/vendor-functions/expand-var-filesystem.sh
+++ b/config/vendor-functions/expand-var-filesystem.sh
@@ -13,7 +13,7 @@ parent_partition=$( lsblk -ndo pkname ${pvs_path} )
 
 volume_to_extend="NONE"
 
-# Deteremine the volume to extend based on whether encrypted /var is used or not
+# Determine the volume to extend based on whether encrypted /var is used or not
 if [[ $var_map =~ "var_decrypted" ]]; then
   volume_to_extend=$( grep var_decrypted /etc/crypttab | awk '{print $2}' )
 else
@@ -33,6 +33,10 @@ LVM_SYSTEM_DIR=/home/.lvm pvresize $pvs_path
 # and it has no effect on systems not using encrypted /var
 if [[ $volume_to_extend != "NONE" ]]; then
   echo "" | LVM_SYSTEM_DIR=/home/.lvm lvextend -r -l +100%FREE ${volume_to_extend}
+fi
+
+if [[ -f "${VX_CONFIG_ROOT}/EXPAND_VAR" ]]; then
+  rm -f "${VX_CONFIG_ROOT}/EXPAND_VAR"
 fi
 
 exit 0;

--- a/config/vendor-functions/show-vendor-menu.sh
+++ b/config/vendor-functions/show-vendor-menu.sh
@@ -12,8 +12,15 @@ if [[ $(tty) = /dev/tty1 ]] && [[ -f "/home/REKEY_VIA_TPM" ]]; then
   sudo "${VX_FUNCTIONS_ROOT}/rekey-via-tpm.sh"
 fi
 
-if [[ $(tty) = /dev/tty1 ]] && [[ -f "${VX_CONFIG_ROOT}/RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT" ]]; then
+# Note: EXPAND_VAR will be created as part of a vx-iso install
+# This prevents the var expansion from running in VMs while other
+# config/setup may be taking place. We only want to expand var
+# on systems installed to physical hardware.
+if [[ $(tty) = /dev/tty1 ]] && [[ -f "${VX_CONFIG_ROOT}/EXPAND_VAR" ]]; then
   sudo "${VX_FUNCTIONS_ROOT}/expand-var-filesystem.sh"
+fi
+
+if [[ $(tty) = /dev/tty1 ]] && [[ -f "${VX_CONFIG_ROOT}/RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT" ]]; then
   "${VX_FUNCTIONS_ROOT}/basic-configuration.sh"
   exit 0
 fi

--- a/config/vendor-functions/show-vendor-menu.sh
+++ b/config/vendor-functions/show-vendor-menu.sh
@@ -18,6 +18,12 @@ fi
 # on systems installed to physical hardware.
 if [[ $(tty) = /dev/tty1 ]] && [[ -f "${VX_CONFIG_ROOT}/EXPAND_VAR" ]]; then
   sudo "${VX_FUNCTIONS_ROOT}/expand-var-filesystem.sh"
+
+  # Note: we should improve this in the future. There's no filesystem need
+  # to reboot. We're only doing so because of our autologin configuration.
+  echo "The /var filesystem has been resized. The system will now reboot."
+  sleep 3
+  sudo /usr/sbin/reboot
 fi
 
 if [[ $(tty) = /dev/tty1 ]] && [[ -f "${VX_CONFIG_ROOT}/RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT" ]]; then

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -317,6 +317,12 @@ sudo ln -sf /var/vx/config /vx/config
 
 sudo ln -s /vx/code/config/read-vx-machine-config.sh /vx/config/read-vx-machine-config.sh
 
+# To support new images installed via older vx-iso releases
+# explicitly set the EXPAND_VAR flag file
+# (This gets set by new vx-iso releases, so we can eventually remove
+# setting the flag here, but it doesn't hurt to leave it)
+sudo touch /vx/config/EXPAND_VAR
+
 # record the machine type in the configuration (-E keeps the environment variable around, CHOICE prefix sends it in)
 CHOICE="${CHOICE}" sudo -E sh -c 'echo "${CHOICE}" > /vx/config/machine-type'
 


### PR DESCRIPTION
This PR updates how the automated expansion of the `/var` partition is performed, based on updates to vx-iso.

It is no longer tied to the basic configuration wizard flow, but is instead reliant on an explicit flag set by the vx-iso flash image process. An explicit reboot has also been added since that was built into the previous basic config wizard flow.