### PR TITLE
fix suspended display bug on amd radeon hardware

### DIFF
--- a/config/logind.conf
+++ b/config/logind.conf
@@ -12,6 +12,11 @@
 # See logind.conf(5) for details.
 
 [Login]
+# Don't take action on Lid Switch actions (fixes issue with amd radeon)
+HandleLidSwitch=ignore
+HandleLidSwitchExternalPower=ignore
+HandleLidSwitchDocked=ignore
+LidSwitchIgnoreInhibited=no
 # shut down on power key (no hibernate or anything.)
 HandlePowerKey=poweroff
 # make sure machine never shuts down on idle


### PR DESCRIPTION
`systemd-logind` controls all kinds of things, it's where we do things like disable idling, powering the system off when the power key is pressed, etc... Well, it also has settings related to lid switches. The defaults are `suspend`, and this display driver/firmware seems to not handle it properly.

```
HandleLidSwitch=ignore
HandleLidSwitchExternalPower=ignore
HandleLidSwitchDocked=ignore
LidSwitchIgnoreInhibited=no
```
Setting these values results in the logind daemon not taking action on lid switches, so comes right back on when you open the lid.

The only downside I can think of here is that since it doesn't suspend, you'd be using more power, but we work pretty hard to make sure systems don't idle/suspend, so this doesn't seem like a concern to me.