### PR TITLE
Update hosts information for vxpollbook machines, kiosk-browser bug fix

### DIFF
--- a/config/sudoers
+++ b/config/sudoers
@@ -21,6 +21,7 @@ root	ALL=(ALL:ALL) ALL
 
 # fine-grained sudo permissions for certain users & actions
 vx-vendor ALL=(root:ALL) NOPASSWD: /vx/vendor/vendor-functions/set-clock.sh
+vx-vendor ALL=(root:ALL) NOPASSWD: /vx/vendor/vendor-functions/choose-vx-machine-id.sh
 vx-vendor ALL=(root:ALL) NOPASSWD: /vx/vendor/vendor-functions/rekey-via-tpm.sh
 vx-vendor ALL=(root:ALL) NOPASSWD: /vx/vendor/vendor-functions/expand-var-filesystem.sh
 vx-vendor ALL=(root:ALL) NOPASSWD: /vx/vendor/vendor-functions/lockdown.sh

--- a/config/sudoers-for-dev
+++ b/config/sudoers-for-dev
@@ -22,6 +22,7 @@ vx-vendor	ALL=(ALL:ALL) ALL
 
 # fine-grained sudo permissions for certain users & actions
 vx-vendor ALL=(root:ALL) NOPASSWD: /vx/vendor/vendor-functions/set-clock.sh
+vx-vendor ALL=(root:ALL) NOPASSWD: /vx/vendor/vendor-functions/choose-vx-machine-id.sh
 vx-vendor ALL=(root:ALL) NOPASSWD: /vx/vendor/vendor-functions/rekey-via-tpm.sh
 vx-vendor ALL=(root:ALL) NOPASSWD: /vx/vendor/vendor-functions/expand-var-filesystem.sh
 vx-vendor ALL=(root:ALL) NOPASSWD: /vx/vendor/vendor-functions/lockdown.sh

--- a/config/vendor-functions/choose-vx-machine-id.sh
+++ b/config/vendor-functions/choose-vx-machine-id.sh
@@ -19,8 +19,8 @@ while true; do
       # If this is a poll-book machine, we update the /etc/hosts file
       # and set the hostname
       if [[ $(cat ${VX_CONFIG_ROOT}/machine-type 2>/dev/null) == "poll-book" ]]; then
-        sudo sed -i.bak "/^127\.0\.1\.1/ s/.*/127.0.1.1\tVx${MACHINE_ID}/" /etc/hosts
-        sudo hostnamectl set-hostname "Vx${MACHINE_ID}" 2>/dev/null
+        sed -i.bak "/^127\.0\.1\.1/ s/.*/127.0.1.1\tVx${MACHINE_ID}/" /etc/hosts
+        hostnamectl set-hostname "Vx${MACHINE_ID}" 2>/dev/null
       fi
 
       echo "Machine ID set!"

--- a/config/vendor-functions/choose-vx-machine-id.sh
+++ b/config/vendor-functions/choose-vx-machine-id.sh
@@ -15,6 +15,14 @@ while true; do
     if [[ "${CONFIRM}" = "y" ]]; then
       mkdir -p "${VX_CONFIG_ROOT}"
       echo "${MACHINE_ID}" > "${VX_CONFIG_ROOT}/machine-id"
+
+      # If this is a poll-book machine, we update the /etc/hosts file
+      # and set the hostname
+      if [[ $(cat ${VX_CONFIG_ROOT}/machine-type 2>/dev/null) == "poll-book" ]]; then
+        sudo sed -i.bak "/^127\.0\.1\.1/ s/.*/127.0.1.1\tVx${MACHINE_ID}/" /etc/hosts
+        sudo hostnamectl set-hostname "Vx${MACHINE_ID}" 2>/dev/null
+      fi
+
       echo "Machine ID set!"
       break
     fi

--- a/run-scripts/run-kiosk-browser.sh
+++ b/run-scripts/run-kiosk-browser.sh
@@ -8,9 +8,5 @@ URL=${1:-http://localhost:3000}
 
 OS=$(lsb_release -cs)
 
-kiosk-browser \
-  --add-file-perm o=http://localhost:3000,p=/media/**/*,rw \
-  --add-file-perm o=http://localhost:3000,p=/var/log,ro \
-  --add-file-perm o=http://localhost:3000,p=/var/log/*,ro \
-  --url ${URL} || true
+kiosk-browser --url ${URL} || true
 


### PR DESCRIPTION
This PR sets hostname information for vxpollbook machines as part of the machine id step in basic configuration.

It also removes the `--add-file-perm` option from kiosk-browser since that option was removed in a recent update.