### PR TITLE
More updates to managing machine-id via sudo

### DIFF
--- a/config/vendor-functions/basic-configuration.sh
+++ b/config/vendor-functions/basic-configuration.sh
@@ -16,7 +16,7 @@ echo "You're going to do great"
 
 echo
 echo -e "\e[1mStep 1: Set Machine ID\e[0m"
-${VX_FUNCTIONS_ROOT}/choose-vx-machine-id.sh
+sudo ${VX_FUNCTIONS_ROOT}/choose-vx-machine-id.sh
 
 echo
 echo -e "\e[1mStep 2: Set Clock\e[0m"

--- a/config/vendor-functions/choose-vx-machine-id.sh
+++ b/config/vendor-functions/choose-vx-machine-id.sh
@@ -5,7 +5,7 @@ set -euo pipefail
 : "${VX_FUNCTIONS_ROOT:="$(dirname "$0")"}"
 : "${VX_CONFIG_ROOT:="/vx/config"}"
 
-if [[ "${VX_MACHINE_ID}" != "0000" ]]; then
+if [[ $(cat ${VX_CONFIG_ROOT}/machine-id 2>/dev/null) != "0000" ]]; then
     echo "Current Machine ID: ${VX_MACHINE_ID}"
 fi
 while true; do

--- a/config/vendor-functions/choose-vx-machine-id.sh
+++ b/config/vendor-functions/choose-vx-machine-id.sh
@@ -19,7 +19,8 @@ while true; do
       # If this is a poll-book machine, we update the /etc/hosts file
       # and set the hostname
       if [[ $(cat ${VX_CONFIG_ROOT}/machine-type 2>/dev/null) == "poll-book" ]]; then
-        sed -i.bak "/^127\.0\.1\.1/ s/.*/127.0.1.1\tVx${MACHINE_ID}/" /etc/hosts
+        sed "/^127\.0\.1\.1/ s/.*/127.0.1.1\tVx${MACHINE_ID}/" /etc/hosts > /var/tmp/hosts
+        cp /var/tmp/hosts /etc/hosts
         hostnamectl set-hostname "Vx${MACHINE_ID}" 2>/dev/null
       fi
 


### PR DESCRIPTION
Now that the choose-machine-id.sh script is run via sudo, we need to access the `machine-id` file directly rather than assuming it's set as an ENV var.

I've also changed the sed command to use a tmp file rather than editing in place. Since the hosts file is in /etc, it will create a temporary file there, along with creating /etc/hosts.bak, and we don't want to try to manage all that once we lock down the image.