### PR TITLE
Make VX_MACHINE_ID accessible to root in choose-vx-machine-id

### DIFF
--- a/config/vendor-functions/choose-vx-machine-id.sh
+++ b/config/vendor-functions/choose-vx-machine-id.sh
@@ -5,7 +5,10 @@ set -euo pipefail
 : "${VX_FUNCTIONS_ROOT:="$(dirname "$0")"}"
 : "${VX_CONFIG_ROOT:="/vx/config"}"
 
-if [[ $(cat ${VX_CONFIG_ROOT}/machine-id 2>/dev/null) != "0000" ]]; then
+# since root does not source the vx machine config
+# we get the machine-id directly
+VX_MACHINE_ID=$(cat ${VX_CONFIG_ROOT}/machine-id 2>/dev/null)
+if [[ "${VX_MACHINE_ID}" != "0000" ]]; then
     echo "Current Machine ID: ${VX_MACHINE_ID}"
 fi
 while true; do


### PR DESCRIPTION
Previously, this script did not require sudo, so env vars like `VX_MACHINE_ID` were available because the vx-vendor user sources the machine config to export all expected env vars. Now that root privileges are required, we need to get the value directly to prevent an unbound variable error when the machine-id is not the default of `0000`.