### PR TITLE
can't use hostnamectl in locked down images

### DIFF
--- a/config/vendor-functions/choose-vx-machine-id.sh
+++ b/config/vendor-functions/choose-vx-machine-id.sh
@@ -24,7 +24,9 @@ while true; do
       if [[ $(cat ${VX_CONFIG_ROOT}/machine-type 2>/dev/null) == "poll-book" ]]; then
         sed "/^127\.0\.1\.1/ s/.*/127.0.1.1\tVx${MACHINE_ID}/" /etc/hosts > /var/tmp/hosts
         cp /var/tmp/hosts /etc/hosts
-        hostnamectl set-hostname "Vx${MACHINE_ID}" 2>/dev/null
+        #hostnamectl set-hostname "Vx${MACHINE_ID}" 2>/dev/null
+        echo "Vx${MACHINE_ID}" > /etc/hostname
+        hostname -F /etc/hostname
       fi
 
       echo "Machine ID set!"


### PR DESCRIPTION
Since vxpollbook makes changes to `/etc/hosts` and `/etc/hostname`, we had to use our standard symlink approach to make those files accessible when locked down. Unfortunately, the `hostnamectl` command destroys the symlink and replaces it with a regular file. That operation will fail on a locked down system. This works around the issue by setting the hostname without using `hostnamectl` and works when locked down.