### PR TITLE
Fix builds: Don't copy over unneeded VxDesign and VxPollBook directories

### DIFF
--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -265,7 +265,11 @@ echo "Setting up the code"
 sudo mv build/${CHOICE} /vx/code
 
 # temporary hack cause of precinct-scanner runtime issue
+#
 sudo rm /vx/code/vxsuite # it's a symlink
+# We have limited space on the root partition so don't copy over the unneeded VxDesign and
+# VxPollBook directories
+rm -r vxsuite/apps/design vxsuite/apps/pollbook
 sudo cp -rp vxsuite /vx/code/
 
 # symlink the code and run-*.sh in /vx/services


### PR DESCRIPTION
## Overview

This is a temporary patch to address running out of space on the root partition (of the VM, not the host machine) during the `setup-machine.sh` step of builds:

```
Setting up the code
cp: error writing '/vx/code/vxsuite/node_modules/.pnpm/stylelint@15.10.2/node_modules/stylelint/lib/rules/unit-no-unknown/index.js': No space left on device
cp: error writing '/vx/code/vxsuite/node_modules/.pnpm/stylelint@15.10.2/node_modules/stylelint/lib/rules/unit-no-unknown/README.md': No space left on device
cp: cannot create directory '/vx/code/vxsuite/node_modules/.pnpm/stylelint@15.10.2/node_modules/stylelint/lib/rules/color-hex-length': No space left on device
...
```

`df -h` indicates that the root partition `Vx--vg-root` in particular is filling up:

```
$ df -h
Filesystem                 Size  Used Avail Use% Mounted on
udev                        56G     0   56G   0% /dev
tmpfs                       12G 1008K   12G   1% /run
/dev/mapper/Vx--vg-root    7.3G  7.3G     0 100% /
tmpfs                       56G     0   56G   0% /dev/shm
tmpfs                      5.0M  8.0K  5.0M   1% /run/lock
efivarfs                   256K   28K  223K  12% /sys/firmware/efi/efivars
/dev/vda2                  227M  227M     0 100% /boot
/dev/mapper/Vx--vg-home     10G  8.8G  691M  93% /home
/dev/mapper/Vx--vg-tmp     919M   40K  856M   1% /tmp
/dev/vda1                  511M  5.9M  506M   2% /boot/efi
/dev/mapper/var_decrypted  6.5G  5.3G  947M  85% /var
tmpfs                       12G  4.0K   12G   1% /run/user/1000
```

The space consuming step in `setup-machine.sh` is `sudo cp -rp vxsuite /vx/code/`. To work around the space errors, I'm pruning out two directories known to be irrelevant to standard VxSuite machine builds, `apps/design` for VxDesign and `apps/pollbook` for VxPollBook.

We should still come up with something more future proof, but this at least unblocks builds for now.