### PR TITLE
VxPollbook: add support for TPM-backed certificate auth via strongswan

### DIFF
--- a/config/vendor-functions/create-machine-cert.sh
+++ b/config/vendor-functions/create-machine-cert.sh
@@ -11,7 +11,7 @@ set -euo pipefail
 : "${VX_MACHINE_ID:="$(< "${VX_CONFIG_ROOT}/machine-id")"}"
 : "${IS_QA_IMAGE:="$(< "${VX_CONFIG_ROOT}/is-qa-image")"}"
 
-CREATE_STRONGSWAN_CERT="0"
+USE_STRONGSWAN_TPM_KEY="0"
 
 if [[ "${VX_MACHINE_TYPE}" == "admin" || "${VX_MACHINE_TYPE}" == "poll-book" ]]; then
     MACHINE_CERT_PATH="${VX_CONFIG_ROOT}/vx-${VX_MACHINE_TYPE}-cert-authority-cert.pem"
@@ -53,7 +53,7 @@ function create_machine_cert_signing_request() {
         VX_MACHINE_TYPE="${VX_MACHINE_TYPE}" \
             VX_MACHINE_ID="${VX_MACHINE_ID}" \
             VX_MACHINE_JURISDICTION="${machine_jurisdiction}" \
-            CREATE_STRONGSWAN_CERT="${CREATE_STRONGSWAN_CERT}" \
+            USE_STRONGSWAN_TPM_KEY="${USE_STRONGSWAN_TPM_KEY}" \
             ./create-production-machine-cert-signing-request
     else
         VX_MACHINE_TYPE="${VX_MACHINE_TYPE}" \
@@ -91,7 +91,7 @@ if [[ "${VX_MACHINE_TYPE}" == "admin" || "${VX_MACHINE_TYPE}" == "poll-book" ]];
     
     # Pollbooks need an additional cert for strongswan using a different TPM handle
     if [[ "${VX_MACHINE_TYPE}" == "poll-book" ]]; then
-      CREATE_STRONGSWAN_CERT="1"
+      USE_STRONGSWAN_TPM_KEY="1"
       create_machine_cert_signing_request "${machine_jurisdiction}" > "${USB_DRIVE_CERTS_DIRECTORY}/pollbook_csr.pem"
     fi
 else

--- a/config/vendor-functions/create-machine-cert.sh
+++ b/config/vendor-functions/create-machine-cert.sh
@@ -145,11 +145,13 @@ if ! openssl x509 -in "${MACHINE_CERT_PATH}" -noout -pubkey | \
 fi
 #
 # Cert correctness check 1 for pollbook
-if ! openssl x509 -in "${STRONGSWAN_X509_PATH}" -noout -pubkey | \
-    diff -q "${VX_CONFIG_ROOT}/pollbook_rsa.pub" -; then
-    echo -e "\e[31mPublic key in pollbook cert doesn't match the public key created by the TPM\e[0m" >&2
-    read -p "Press enter to start over. "
-    exit 1
+if [[ "${VX_MACHINE_TYPE}" == "poll-book" ]]; then
+  if ! openssl x509 -in "${STRONGSWAN_X509_PATH}" -noout -pubkey | \
+      diff -q "${VX_CONFIG_ROOT}/pollbook_rsa.pub" -; then
+      echo -e "\e[31mPublic key in pollbook cert doesn't match the public key created by the TPM\e[0m" >&2
+      read -p "Press enter to start over. "
+      exit 1
+  fi
 fi
 
 # Cert correctness check 2
@@ -164,12 +166,14 @@ if ! openssl verify \
 fi
 
 # Cert correctness check 2 for pollbook
-if ! openssl verify \
-    -attime "$(date -d "+10 minutes" +%s)" \
-    -CAfile "${VX_METADATA_ROOT}/vxsuite/libs/auth/certs/prod/vx-cert-authority-cert.pem" "${STRONGSWAN_X509_PATH}" > /dev/null; then
-    echo -e "\e[31mPollbook cert was not signed by the correct cert authority or is not yet valid because of a clock mismatch\e[0m" >&2
-    read -p "Press enter to start over. "
-    exit 1
+if [[ "${VX_MACHINE_TYPE}" == "poll-book" ]]; then
+  if ! openssl verify \
+      -attime "$(date -d "+10 minutes" +%s)" \
+      -CAfile "${VX_METADATA_ROOT}/vxsuite/libs/auth/certs/prod/vx-cert-authority-cert.pem" "${STRONGSWAN_X509_PATH}" > /dev/null; then
+      echo -e "\e[31mPollbook cert was not signed by the correct cert authority or is not yet valid because of a clock mismatch\e[0m" >&2
+      read -p "Press enter to start over. "
+      exit 1
+  fi
 fi
 
 echo "Machine cert(s) saved! You can remove the USB drive."

--- a/config/vendor-functions/create-machine-cert.sh
+++ b/config/vendor-functions/create-machine-cert.sh
@@ -19,13 +19,14 @@ USE_STRONGSWAN_TPM_KEY="0"
 
 if [[ "${VX_MACHINE_TYPE}" == "admin" || "${VX_MACHINE_TYPE}" == "poll-book" ]]; then
     MACHINE_CERT_PATH="${VX_CONFIG_ROOT}/vx-${VX_MACHINE_TYPE}-cert-authority-cert.pem"
-else
-    MACHINE_CERT_PATH="${VX_CONFIG_ROOT}/vx-${VX_MACHINE_TYPE}-cert.pem"
     if [[ "${VX_MACHINE_TYPE}" == "poll-book" ]]; then
       STRONGSWAN_X509_PATH="/etc/swanctl/x509/vx-poll-book-strongswan-rsa-cert.pem"
       STRONGSWAN_CA_PATH="/etc/swanctl/x509ca/vx-cert-authority-cert.pem"
     fi
+else
+    MACHINE_CERT_PATH="${VX_CONFIG_ROOT}/vx-${VX_MACHINE_TYPE}-cert.pem"
 fi
+
 USB_DRIVE_CERTS_DIRECTORY="/media/vx/usb-drive/certs"
 VX_IANA_ENTERPRISE_OID="1.3.6.1.4.1.59817"
 

--- a/config/vendor-functions/generate-key.sh
+++ b/config/vendor-functions/generate-key.sh
@@ -59,7 +59,7 @@ if [[ "${machine_type}" == "poll-book" ]]; then
 
   # Using that key, create a persistent RSA attestation key
   # also outputs the public portion in PEM format for later verification
-  tpm2_createak -C "${ek_handle}" -G rsa -s rsassa -c ak_rsa.ctx -f pem -u "${VX_CONFIG_ROOT}/pollbook_rsa.pub"
+  tpm2_createak -C "${ek_handle}" -G rsa -s rsassa -c ak_rsa.ctx -f pem -u "${VX_CONFIG_ROOT}/vx-poll-book-strongswan-rsa-cert.pub"
   tpm2_evictcontrol -Q -c "${ak_handle}" &> /dev/null || true
   tpm2_evictcontrol -c ak_rsa.ctx "${ak_handle}"
 fi

--- a/config/vendor-functions/generate-key.sh
+++ b/config/vendor-functions/generate-key.sh
@@ -58,7 +58,8 @@ if [[ "${machine_type}" == "poll-book" ]]; then
   tpm2_createek -G rsa -c "${ek_handle}"
 
   # Using that key, create a persistent RSA attestation key
-  tpm2_createak -C "${ek_handle}" -G rsa -s rsassa -c ak_rsa.ctx 
+  # also outputs the public portion in PEM format for later verification
+  tpm2_createak -C "${ek_handle}" -G rsa -s rsassa -c ak_rsa.ctx -f pem -u "${VX_CONFIG_ROOT}/pollbook_rsa.pub"
   tpm2_evictcontrol -Q -c "${ak_handle}" &> /dev/null || true
   tpm2_evictcontrol -c ak_rsa.ctx "${ak_handle}"
 fi

--- a/config/vendor-functions/generate-key.sh
+++ b/config/vendor-functions/generate-key.sh
@@ -46,3 +46,20 @@ tpm2_readpublic -c key.ctx -f PEM -o "${VX_CONFIG_ROOT}/key.pub"
 
 chmod +r "${VX_CONFIG_ROOT}/key.pub"
 
+# poll-book machines require the creation of endorsement and
+# attestation keys used by strongswan for tpm authentication
+machine_type=$(cat ${VX_CONFIG_ROOT}/machine-type 2>/dev/null)
+if [[ "${machine_type}" == "poll-book" ]]; then
+  ek_handle="0x81000003"
+  ak_handle="0x81010003"
+  echo "Setting up TPM keys for pollbook..."
+  # First, create a persistent RSA endorsement key
+  tpm2_evictcontrol -Q -c "${ek_handle}" &> /dev/null || true
+  tpm2_createek -G rsa -c "${ek_handle}"
+
+  # Using that key, create a persistent RSA attestation key
+  tpm2_createak -C "${ek_handle}" -G rsa -s rsassa -c ak_rsa.ctx 
+  tpm2_evictcontrol -Q -c "${ak_handle}" &> /dev/null || true
+  tpm2_evictcontrol -c ak_rsa.ctx "${ak_handle}"
+fi
+

--- a/config/vendor-functions/vx-certifier.sh
+++ b/config/vendor-functions/vx-certifier.sh
@@ -16,8 +16,8 @@ set -euo pipefail
 SERIAL_FILE="/tmp/serial.txt"
 CSR_PATH="/media/vx/usb-drive/certs/csr.pem"
 CERT_PATH="/media/vx/usb-drive/certs/cert.pem"
-STRONGSWAN_CSR_PATH="/media/vx/usb-drive/certs/pollbook_csr.pem"
-STRONGSWAN_CERT_PATH="/media/vx/usb-drive/certs/pollbook_cert.pem"
+STRONGSWAN_CSR_PATH="/media/vx/usb-drive/certs/vx-poll-book-strongswan-csr.pem"
+STRONGSWAN_CERT_PATH="/media/vx/usb-drive/certs/vx-poll-book-strongswan-cert.pem"
 
 rm -f "${SERIAL_FILE}"
 

--- a/config/vendor-functions/vx-certifier.sh
+++ b/config/vendor-functions/vx-certifier.sh
@@ -37,8 +37,6 @@ CMD=(
 # TODO: rethink multiple cert case, this is just a quick workaround
 # as a temporary solution for pollbook strongswan testing this is fine
 # but what if we find ourselves with > 2 certs in the future?
-# TODO: add error checking/confirmation for pollbook strongswan?
-# assuming success for now during testing
 if [[ -f "$STRONGSWAN_CSR_PATH" ]]; then
   echo
   echo "Found a pollbook strongswan cert request. Processing it first..."


### PR DESCRIPTION
This PR adds the necessary support for certificate-based authentication (backed by the TPM) between mesh-connected pollbook machines. Of note:

- New keys are created in the TPM. These keys are different than our existing key, and you can learn more in the [Strongswan TPM docs](https://docs.strongswan.org/docs/latest/tpm/tpm2.html)
- The existing cert creation/verification processes were updated to include the use of the new TPM handle. That also required an update in vxsuite, [seen here](https://github.com/votingworks/vxsuite/commit/eaa341ca1cf5bf8b7d0f5d17f76ff5b07553808c).