### PR TITLE
Add support for running fipsinstall outside basic config wizard

### DIFF
--- a/config/vendor-functions/show-vendor-menu.sh
+++ b/config/vendor-functions/show-vendor-menu.sh
@@ -12,9 +12,9 @@ if [[ $(tty) = /dev/tty1 ]] && [[ -f "/home/REKEY_VIA_TPM" ]]; then
   sudo "${VX_FUNCTIONS_ROOT}/rekey-via-tpm.sh"
 fi
 
-if [[ $(tty) = /dev/tty1 ]] && [[ -f "${VX_CONFIG_ROOT}/FIPS_INSTALL" ]]; then
+if [[ $(tty) = /dev/tty1 ]] && [[ -f "${VX_CONFIG_ROOT}/RUN_FIPS_INSTALL" ]]; then
   sudo "${VX_FUNCTIONS_ROOT}/fipsinstall.sh"
-  rm -f "${VX_CONFIG_ROOT}/FIPS_INSTALL"
+  rm -f "${VX_CONFIG_ROOT}/RUN_FIPS_INSTALL"
 fi
 
 # Note: EXPAND_VAR will be created as part of a vx-iso install

--- a/config/vendor-functions/show-vendor-menu.sh
+++ b/config/vendor-functions/show-vendor-menu.sh
@@ -26,9 +26,9 @@ if [[ $(tty) = /dev/tty1 ]] && [[ -f "${VX_CONFIG_ROOT}/EXPAND_VAR" ]]; then
 
   # Note: we should improve this in the future. There's no filesystem need
   # to reboot. We're only doing so because of our autologin configuration.
-  #echo "The /var filesystem has been resized. The system will now reboot."
-  #sleep 3
-  #sudo /usr/sbin/reboot
+  echo "The /var filesystem has been resized. The system will now reboot."
+  sleep 3
+  sudo /usr/sbin/reboot
 fi
 
 if [[ $(tty) = /dev/tty1 ]] && [[ -f "${VX_CONFIG_ROOT}/RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT" ]]; then

--- a/config/vendor-functions/show-vendor-menu.sh
+++ b/config/vendor-functions/show-vendor-menu.sh
@@ -12,6 +12,11 @@ if [[ $(tty) = /dev/tty1 ]] && [[ -f "/home/REKEY_VIA_TPM" ]]; then
   sudo "${VX_FUNCTIONS_ROOT}/rekey-via-tpm.sh"
 fi
 
+if [[ $(tty) = /dev/tty1 ]] && [[ -f "${VX_CONFIG_ROOT}/FIPS_INSTALL" ]]; then
+  sudo "${VX_FUNCTIONS_ROOT}/fipsinstall.sh"
+  rm -f "${VX_CONFIG_ROOT}/FIPS_INSTALL"
+fi
+
 # Note: EXPAND_VAR will be created as part of a vx-iso install
 # This prevents the var expansion from running in VMs while other
 # config/setup may be taking place. We only want to expand var
@@ -21,9 +26,9 @@ if [[ $(tty) = /dev/tty1 ]] && [[ -f "${VX_CONFIG_ROOT}/EXPAND_VAR" ]]; then
 
   # Note: we should improve this in the future. There's no filesystem need
   # to reboot. We're only doing so because of our autologin configuration.
-  echo "The /var filesystem has been resized. The system will now reboot."
-  sleep 3
-  sudo /usr/sbin/reboot
+  #echo "The /var filesystem has been resized. The system will now reboot."
+  #sleep 3
+  #sudo /usr/sbin/reboot
 fi
 
 if [[ $(tty) = /dev/tty1 ]] && [[ -f "${VX_CONFIG_ROOT}/RUN_BASIC_CONFIGURATION_ON_NEXT_BOOT" ]]; then


### PR DESCRIPTION
In the event config persistence is enabled during a vx-iso install, we need to ensure the `openssl fipsinstall` process runs to meet FIPS compliance standards. 