### PR TITLE
Fix hanging vxmark vm when vx-vendor has logged in via tty

### DIFF
--- a/config/mark_scan_admin_bash_profile
+++ b/config/mark_scan_admin_bash_profile
@@ -1,4 +1,7 @@
-echo 3 | sudo /usr/bin/tee -a /sys/class/graphics/fbcon/rotate
+# Only perform fbcon-based rotation on real hardware
+if [[ $(hostnamectl chassis) != "vm" ]]; then
+  echo 3 | sudo /usr/bin/tee -a /sys/class/graphics/fbcon/rotate
+fi
 export PATH=/vx/code/config/vendor-functions:${PATH}
 
 while true; do


### PR DESCRIPTION
Our screen rotation hack for the vx-vendor user on VSAP hardware causes VMs to hang indefinitely on reboot/shutdown. This only performs screen rotation when running on non-VM systems.