### PR TITLE
Improve dm-verity boot logging

### DIFF
--- a/config/30-votingworks.conf
+++ b/config/30-votingworks.conf
@@ -120,4 +120,4 @@ template(name="dmverityBoot" type="list" option.jsonf="on") {
     property(outname="message" name="msg" format="jsonf")
 }
 
-if $msg contains "verity" then /var/log/votingworks/vx-logs.log;dmverityBoot
+if $syslogtag == "systemd[1]:" and $msg contains "Reached target veritysetup" then /var/log/votingworks/vx-logs.log;dmverityBoot

--- a/config/rsyslog.conf
+++ b/config/rsyslog.conf
@@ -11,7 +11,7 @@
 #################
 
 #module(load="imuxsock") # provides support for local system logging
-module(load="imjournal" PersistStateInterval="100" StateFile="state")
+module(load="imjournal" PersistStateInterval="10" StateFile="state")
 
 #module(load="mmjsonparse")
 


### PR DESCRIPTION
In some scenarios, it's possible to not see dm-verity boot related messages shortly after a system is booted, including when logs are exported. This PR changes our default buffer from 100 log lines being processed down to 10 so that logs are written to disk more frequently. In addition, the dm-verity filter has been updated to only include the successful boot state rather than all verity related logs. 