### PR TITLE
Allow VxMark ATI/PAT daemon to restart more than 10 times in 5 minutes

### DIFF
--- a/config/mark-scan-fai-100-daemon.service
+++ b/config/mark-scan-fai-100-daemon.service
@@ -1,7 +1,7 @@
 [Unit]
 Description=VotingWorks daemon that handles BMD 150 controller and PAT signal.
 StartLimitIntervalSec=300
-StartLimitBurst=10
+StartLimitBurst=30
 
 [Service]
 Restart=on-failure


### PR DESCRIPTION
In the first round of ESD testing, we found that zapping the PAT jack causes the ATI/PAT daemon to crash. Thankfully, restarting the daemon restores operations, and we worked on a change for the second round of ESD testing to automate that restarting. Reminder that in ESD testing, the machine must recover without human intervention, i.e., without a physical restart of the device.

The above patch worked in this second round of ESD testing but also left us on the edge of our seats because it came to our attention that each point of interest is zapped not once but 10 times. Our current config does allow exactly 10 starts within a 5-minute window. But it's unclear whether that 10 starts is 10 restarts or 10 starts including the original start.

Anyhow, while we got through this part of ESD testing fine, we still have to redo ESD testing for other reasons. And I'd rather we play it safe for the retest and allow ourselves to restart more often. I've opted for a max of 30 starts within a 5-minute window.