### PR TITLE
Run fipsinstall before operations that require openssl

### DIFF
--- a/config/vendor-functions/show-vendor-menu.sh
+++ b/config/vendor-functions/show-vendor-menu.sh
@@ -8,13 +8,13 @@ set -euo pipefail
 : "${VX_CONFIG_ROOT:="/vx/config"}"
 : "${VX_METADATA_ROOT:="/vx/code"}"
 
-if [[ $(tty) = /dev/tty1 ]] && [[ -f "/home/REKEY_VIA_TPM" ]]; then
-  sudo "${VX_FUNCTIONS_ROOT}/rekey-via-tpm.sh"
-fi
-
 if [[ $(tty) = /dev/tty1 ]] && [[ -f "${VX_CONFIG_ROOT}/RUN_FIPS_INSTALL" ]]; then
   sudo "${VX_FUNCTIONS_ROOT}/fipsinstall.sh"
   rm -f "${VX_CONFIG_ROOT}/RUN_FIPS_INSTALL"
+fi
+
+if [[ $(tty) = /dev/tty1 ]] && [[ -f "/home/REKEY_VIA_TPM" ]]; then
+  sudo "${VX_FUNCTIONS_ROOT}/rekey-via-tpm.sh"
 fi
 
 # Note: EXPAND_VAR will be created as part of a vx-iso install


### PR DESCRIPTION
We (currently) persist the fipsmodule.cnf across installs, but if there are other kernel/system level upgrades between different versions, it can cause the fipsmodule.cnf to be invalid until it's installed/verified again. This PR runs the necessary fips install/verification process before other operations so that we guarantee an updated and valid fips configuration for the newly installed version of an application.