### PR TITLE
reduce sudo chatter in logs

### DIFF
--- a/config/30-votingworks.conf
+++ b/config/30-votingworks.conf
@@ -80,7 +80,9 @@ template(name="machineShutdownSuccess" type="list" option.jsonf="on") {
 if $programname == "systemd-logind" and ($msg contains "System is rebooting" or $msg contains "System is powering down") then /var/log/votingworks/vx-logs.log;machineShutdownInit
 if $syslogtag == "systemd[1]:" and $msg contains "Stopped systemd-update-utmp.service" then /var/log/votingworks/vx-logs.log;machineShutdownSuccess
 
-## Sudo actions
+## Route sudo logs, except for session open/close logs which don't provide additional information
+if $syslogtag contains "sudo" and re_match($msg, "pam_unix\\(sudo:session\\): session (opened|closed) for user") then stop
+
 template(name="sudoAction" type="list" option.jsonf="on") {
     property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")
     property(outname="host" name="hostname" format="jsonf")
@@ -92,7 +94,7 @@ template(name="sudoAction" type="list" option.jsonf="on") {
     property(outname="message" name="msg" format="jsonf")
 }
 
-if $syslogtag contains "sudo" then /var/log/votingworks/vx-logs.log;sudoAction
+if $syslogtag contains "sudo" and $msg contains "COMMAND=" then /var/log/votingworks/vx-logs.log;sudoAction
 
 ## Password changes
 template(name="passwdChange" type="list" option.jsonf="on") {


### PR DESCRIPTION
We route all `sudo` logs to `vx-logs.log`. For PulseAudio control, we're polling with `sudo`. In fact we make two `sudo` calls, as part of a "`sudo` bounce." These sudo logs end up being the majority of the log files for anything we're using PulseAudio on, like VxMark, VxScan, and VxMarkScan. 

This PR trims out all the useless `pam_unix(sudo:session)` lines that simply tell you a session was opened or closed - we can infer that from the other `sudo` lines that actually show the command. This will reduce log sizes from 30% - 70%, which will help tamp down some of the large log files we've seen during certification. And make them generally easier to read. 

This is a worthwhile improvement in itself, but later on we might consider:
- whitelisting certain sudo calls so they don't go to `vx-logs.log`
- updating how we call `pactl` to only use `sudo` once, there may be a way