### PR TITLE
fix `sudo` logging and add whitelist

### DIFF
--- a/config/30-votingworks.conf
+++ b/config/30-votingworks.conf
@@ -93,14 +93,15 @@ template(name="sudoAction" type="list" option.jsonf="on") {
 }
 
 if $syslogtag contains "sudo" then {
-    # let sudo session open/close messages just go to auth.log, since they do not provide additional information
+    # ignore sudo session open/close messages, since they do not provide additional information
     if $msg contains "pam_unix(sudo:session): session opened for user" then set $.sudo_log_handling = "ignore";
     if $msg contains "pam_unix(sudo:session): session closed for user" then set $.sudo_log_handling = "ignore";
 
-    # whitelist certain sudo messages that we are polling
+    # ignore certain sudo messages that we are polling
     if $msg contains "COMMAND=/usr/bin/pactl -fjson list sinks" then set $.sudo_log_handling = "ignore";
     if $msg contains "COMMAND=/vx/code/app-scripts/pactl.sh -fjson list sinks" then set $.sudo_log_handling = "ignore";
 
+    # messages go to both auth.log and vx-logs.log unless ignored, in which case they go only to auth.log
     if $.sudo_log_handling != "ignore" then /var/log/votingworks/vx-logs.log;sudoAction
 }
     

--- a/config/30-votingworks.conf
+++ b/config/30-votingworks.conf
@@ -80,9 +80,7 @@ template(name="machineShutdownSuccess" type="list" option.jsonf="on") {
 if $programname == "systemd-logind" and ($msg contains "System is rebooting" or $msg contains "System is powering down") then /var/log/votingworks/vx-logs.log;machineShutdownInit
 if $syslogtag == "systemd[1]:" and $msg contains "Stopped systemd-update-utmp.service" then /var/log/votingworks/vx-logs.log;machineShutdownSuccess
 
-## Route sudo logs, except for session open/close logs which don't provide additional information
-if $syslogtag contains "sudo" and re_match($msg, "pam_unix\\(sudo:session\\): session (opened|closed) for user") then stop
-
+## sudo log handling
 template(name="sudoAction" type="list" option.jsonf="on") {
     property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")
     property(outname="host" name="hostname" format="jsonf")
@@ -94,8 +92,18 @@ template(name="sudoAction" type="list" option.jsonf="on") {
     property(outname="message" name="msg" format="jsonf")
 }
 
-if $syslogtag contains "sudo" and $msg contains "COMMAND=" then /var/log/votingworks/vx-logs.log;sudoAction
+if $syslogtag contains "sudo" then {
+    # let sudo session open/close messages just go to auth.log, since they do not provide additional information
+    if $msg contains "pam_unix(sudo:session): session opened for user" then set $.sudo_log_handling = "ignore";
+    if $msg contains "pam_unix(sudo:session): session closed for user" then set $.sudo_log_handling = "ignore";
 
+    # whitelist certain sudo messages that we are polling
+    if $msg contains "COMMAND=/usr/bin/pactl -fjson list sinks" then set $.sudo_log_handling = "ignore";
+    if $msg contains "COMMAND=/vx/code/app-scripts/pactl.sh -fjson list sinks" then set $.sudo_log_handling = "ignore";
+
+    if $.sudo_log_handling != "ignore" then /var/log/votingworks/vx-logs.log;sudoAction
+}
+    
 ## Password changes
 template(name="passwdChange" type="list" option.jsonf="on") {
     property(outname="timeLogWritten" name="timereported" dateformat="rfc3339" format="jsonf")

--- a/config/30-votingworks.conf
+++ b/config/30-votingworks.conf
@@ -101,7 +101,8 @@ if $syslogtag contains "sudo" then {
     if $msg contains "COMMAND=/usr/bin/pactl -fjson list sinks" then set $.sudo_log_handling = "ignore";
     if $msg contains "COMMAND=/vx/code/app-scripts/pactl.sh -fjson list sinks" then set $.sudo_log_handling = "ignore";
 
-    # messages go to both auth.log and vx-logs.log unless ignored, in which case they go only to auth.log
+    # messages go to both auth.log and vx-logs.log unless tagged as "ignore", in which case they go only to auth.log
+    # auth.log is compressed daily and rarely inspected, so we do not need to worry about it growing too large
     if $.sudo_log_handling != "ignore" then /var/log/votingworks/vx-logs.log;sudoAction
 }
     


### PR DESCRIPTION
My previous PR #474 had a couple errors:
- By calling `stop` on the session closed and open logs, they weren't even being forwarded to` auth.log`. While I think we may want to `stop` those eventually, that wasn't the goal and I think that requires more conversation
- By filtering on `COMMAND=` for other `sudo` logs, we were filtering out some things like failed password attempts that we definitely want to keep

This change does a few things:
- reorganizes the logic so it's clearer that all logs not explicitly excluded go to vx-logs
- makes sure we don't `stop` on any sudo logs, so all go to `auth.log`
- adds whitelisting (i.e. goes only to `auth.log`) for the spammed sudo commands on precinct equipment, which further cuts log size in half