### PR TITLE
Move base user/group creation/management to build-system

### DIFF
--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -143,9 +143,6 @@ sudo ln -sf /var/vx/services /vx/services
 # remove all files created by default
 sudo rm -rf /vx/services/* /vx/ui/* /vx/vendor/*
 
-# Let all of our users read logs
-sudo usermod -aG adm vx-vendor
-
 # Set up log config
 sudo bash setup-scripts/setup-logging.sh
 


### PR DESCRIPTION
This PR is tied to https://github.com/votingworks/vxsuite-build-system/pull/184. It removes base user/group management from setup-machine.sh in favor of an ansible playbook in build-system. 