### PR TITLE
remove brother printer path from cupsd apparmor config

### DIFF
--- a/config/apparmor.d/usr.sbin.cupsd
+++ b/config/apparmor.d/usr.sbin.cupsd
@@ -136,7 +136,6 @@
 
   # FIXME: no policy ATM for hplip and Brother drivers
   /usr/bin/hpijs Cx -> third_party,
-  /usr/Brother/** Cx -> third_party,
 
   # Kerberos authentication
   /etc/krb5.conf r,


### PR DESCRIPTION
We no longer support brother printers, so the deprecated path can be removed from the cupsd apparmor config.