### PR TITLE
Support updated build partition layout

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -26,7 +26,7 @@ local_user_home_dir=$( getent passwd "${local_user}" | cut -d: -f6 )
 # Make sure PATH includes cargo and /sbin
 export PATH="${local_user_home_dir}/.cargo/bin:${PATH}:/sbin/"
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd -P)"
 
 # Define vxsuite apps that can be built, along with the expected path prefix
 ALL_APPS=(admin central-scan mark mark-scan print scan)

--- a/config/vx-cleanup.sh
+++ b/config/vx-cleanup.sh
@@ -11,17 +11,19 @@ LVM_DEVICE_PATH="/dev/Vx-vg/vxbuild"
 /usr/bin/rm -f /var/log/syslog
 /usr/bin/rm -f /var/log/votingworks/*
 
+# fstrim the build volume. It must be mounted or space won't
+# be reclaimed
 # unmount the LVM build volume
 # Remove it from /etc/fstab
-# Remove the LVM volume
+# Remove the LVM volume so space can be used by /var later
 if mountpoint -q "${LVM_BUILD_MOUNT_PATH}"; then
+  fstrim "${LVM_BUILD_MOUNT_PATH}"
   umount "${LVM_BUILD_MOUNT_PATH}"
   sed -i -e /vxbuild/d /etc/fstab
   if lvdisplay "${LVM_DEVICE_PATH}"; then
     lvremove -f /dev/Vx-vg/vxbuild
   fi
 fi
-
 
 /usr/bin/systemctl disable vx-cleanup.service
 

--- a/config/vx-cleanup.sh
+++ b/config/vx-cleanup.sh
@@ -6,7 +6,6 @@ LVM_DEVICE_PATH="/dev/Vx-vg/vxbuild"
 # Various files and directories to clean up during
 # VM shutdown in the build process
 /usr/bin/find "$(realpath /home/vx)" -mindepth 1 -delete
-/usr/bin/rm -rf /var/opt/code
 /usr/bin/rm -f /var/log/*.log
 /usr/bin/rm -f /var/log/syslog
 /usr/bin/rm -f /var/log/votingworks/*

--- a/config/vx-cleanup.sh
+++ b/config/vx-cleanup.sh
@@ -1,11 +1,28 @@
 #!/bin/bash
 
+LVM_BUILD_MOUNT_PATH="/vxbuild"
+LVM_DEVICE_PATH="/dev/Vx-vg/vxbuild"
+
 # Various files and directories to clean up during
 # VM shutdown in the build process
-/usr/bin/find /home/vx -mindepth 1 -delete
+/usr/bin/find "$(realpath /home/vx)" -mindepth 1 -delete
+/usr/bin/rm -rf /var/opt/code
 /usr/bin/rm -f /var/log/*.log
 /usr/bin/rm -f /var/log/syslog
 /usr/bin/rm -f /var/log/votingworks/*
+
+# unmount the LVM build volume
+# Remove it from /etc/fstab
+# Remove the LVM volume
+if mountpoint -q "${LVM_BUILD_MOUNT_PATH}"; then
+  umount "${LVM_BUILD_MOUNT_PATH}"
+  sed -i -e /vxbuild/d /etc/fstab
+  if lvdisplay "${LVM_DEVICE_PATH}"; then
+    lvremove -f /dev/Vx-vg/vxbuild
+  fi
+fi
+
+
 /usr/bin/systemctl disable vx-cleanup.service
 
 exit 0

--- a/prepare_build.sh
+++ b/prepare_build.sh
@@ -26,7 +26,7 @@ local_user_home_dir=$( getent passwd "${local_user}" | cut -d: -f6 )
 # Make sure PATH includes cargo and /sbin
 export PATH="${local_user_home_dir}/.cargo/bin:${PATH}:/sbin/"
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd -P)"
 
 # Define vxsuite apps that can be built, along with the expected path prefix
 ALL_APPS=(admin central-scan mark mark-scan print scan)


### PR DESCRIPTION
A new partition layout has been defined in build-system. This PR adds support for that change. Of note:

- The `build.sh` and `prepare-build.sh` scripts now bypass the symlink to get the real physical location on disk. Without this, the build will error with recursive build errors.
- The cleanup script reclaims `/vxbuild` space and deletes the LVM volume. This makes the previously used `/vxbuild` space available to the `/var` partition when the final resize is done on physical hardware.