### PR TITLE
Remove mark-scan specific profile rotation

### DIFF
--- a/config/mark_scan_admin_bash_profile
+++ b/config/mark_scan_admin_bash_profile
@@ -1,6 +1,0 @@
-export PATH=/vx/code/config/vendor-functions:${PATH}
-
-while true; do
-    bash /vx/vendor/vendor-functions/show-vendor-menu.sh
-done
-

--- a/config/mark_scan_admin_bash_profile
+++ b/config/mark_scan_admin_bash_profile
@@ -1,7 +1,3 @@
-# Only perform fbcon-based rotation on real hardware
-if [[ $(hostnamectl chassis) != "vm" ]]; then
-  echo 3 | sudo /usr/bin/tee -a /sys/class/graphics/fbcon/rotate
-fi
 export PATH=/vx/code/config/vendor-functions:${PATH}
 
 while true; do

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -196,11 +196,7 @@ sudo mkdir -p /vx/ui/.config/gtk-3.0
 sudo ln -s /vx/code/config/gtksettings.ini /vx/ui/.config/gtk-3.0/settings.ini
 
 # vendor function scripts
-if [ "${CHOICE}" = "mark-scan" ]; then
-  sudo ln -s /vx/code/config/mark_scan_admin_bash_profile /vx/vendor/.bash_profile
-else
-  sudo ln -s /vx/code/config/admin_bash_profile /vx/vendor/.bash_profile
-fi
+sudo ln -s /vx/code/config/admin_bash_profile /vx/vendor/.bash_profile
 sudo ln -s /vx/code/config/vendor-functions /vx/vendor/vendor-functions
 
 # Make sure our cmdline file is readable by vx-vendor


### PR DESCRIPTION
During early mark-scan testing/development, we added an automatic screen rotation for terminal sessions. This was purely for convenience and has no bearing on production use. That said, it introduced a potential attack via privileged use of the `tee` command. This PR removes that configuration in favor of security over convenience. If this hardware configuration and screen rotation warrants future support, we can re-enable without the use of a privileged `tee` command. Until then, it's best to simply remove.