### PR TITLE
sanitize vendor menu input to prevent bash injection vulnerability

### DIFF
--- a/config/vendor-functions/show-vendor-menu.sh
+++ b/config/vendor-functions/show-vendor-menu.sh
@@ -127,7 +127,13 @@ while true; do
   echo
   read -p "Select menu item: " CHOICE_INDEX
 
-  CHOICE=${CHOICES[$CHOICE_INDEX]}
+  # Protect from malicious input, only accept 0-99 as input
+  if ! [[ "$CHOICE_INDEX" =~ ^[0-9]{1,2}$ ]]; then
+    CHOICE="invalid"
+  else
+    CHOICE=${CHOICES[$CHOICE_INDEX]}
+  fi
+
   case "${CHOICE}" in
     reboot)
       sudo /usr/sbin/reboot

--- a/config/vendor-functions/show-vendor-menu.sh
+++ b/config/vendor-functions/show-vendor-menu.sh
@@ -130,6 +130,9 @@ while true; do
   # Protect from malicious input, only accept 0-99 as input
   if ! [[ "$CHOICE_INDEX" =~ ^[0-9]{1,2}$ ]]; then
     CHOICE="invalid"
+  # Add a range check to be thorough
+  elif (( $CHOICE_INDEX >= ${#CHOICES[@]} )); then
+    CHOICE="invalid"
   else
     CHOICE=${CHOICES[$CHOICE_INDEX]}
   fi


### PR DESCRIPTION
This PR addresses a potential attack vector identified via the vendor menu. With a specifically crafted menu input, an attacker could gain console access as the vx-vendor user and their associated privileges. While that is protected by additional limitations, we still want to prevent this entry point. By sanitizing the input, we can prevent the console access. 

I went with a regex check instead of the recommended `printf` approach since it was accepting octal, hex, and other inputs (including leading whitespaces). I did not create actual attacks via that approach, but it seemed better to eliminate it entirely.