### PR TITLE
Prevent system signals from exiting to a console

### DIFF
--- a/config/autologin.sh
+++ b/config/autologin.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+trap '' SIGINT SIGTSTP SIGQUIT
+
 # This script is designed to be run in override.conf file for the service getty@tty1.
 # It conditionally selects which user to automatically log in as, based on whether or not the
 # machine 1) needs configuration or 2) is being rebooted into the vendor menu.

--- a/config/vendor-functions/basic-configuration.sh
+++ b/config/vendor-functions/basic-configuration.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+trap '' SIGINT SIGTSTP SIGQUIT
+
 setfont /usr/share/consolefonts/Lat7-Terminus32x16.psf.gz 
 
 set -euo pipefail

--- a/config/vendor-functions/choose-vx-machine-id.sh
+++ b/config/vendor-functions/choose-vx-machine-id.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+trap '' SIGINT SIGTSTP SIGQUIT
+
 set -euo pipefail
 
 : "${VX_FUNCTIONS_ROOT:="$(dirname "$0")"}"

--- a/config/vendor-functions/choose-vx-machine-model-name.sh
+++ b/config/vendor-functions/choose-vx-machine-model-name.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+trap '' SIGINT SIGTSTP SIGQUIT
+
 set -euo pipefail
 
 : "${VX_CONFIG_ROOT:="/vx/config"}"

--- a/config/vendor-functions/create-machine-cert.sh
+++ b/config/vendor-functions/create-machine-cert.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Requires sudo
+trap '' SIGINT SIGTSTP SIGQUIT
 
 set -euo pipefail
 

--- a/config/vendor-functions/expand-var-filesystem.sh
+++ b/config/vendor-functions/expand-var-filesystem.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+trap '' SIGINT SIGTSTP SIGQUIT
+
 set -euo pipefail
 
 # Find the mapped device for /var, need this to look up the LV later

--- a/config/vendor-functions/fipsinstall.sh
+++ b/config/vendor-functions/fipsinstall.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Requires sudo
+trap '' SIGINT SIGTSTP SIGQUIT
 
 set -euo pipefail
 

--- a/config/vendor-functions/generate-key.sh
+++ b/config/vendor-functions/generate-key.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+trap '' SIGINT SIGTSTP SIGQUIT
+
 set -euo pipefail
 
 : "${VX_CONFIG_ROOT:="/vx/config"}"

--- a/config/vendor-functions/program-system-administrator-cards.sh
+++ b/config/vendor-functions/program-system-administrator-cards.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Requires sudo
+trap '' SIGINT SIGTSTP SIGQUIT
 
 set -euo pipefail
 

--- a/config/vendor-functions/rekey-via-tpm.sh
+++ b/config/vendor-functions/rekey-via-tpm.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+trap '' SIGINT SIGTSTP SIGQUIT
+
 set -euo pipefail
 
 # Since this script excecutes well before the entirety of systemd

--- a/config/vendor-functions/reset-totp.sh
+++ b/config/vendor-functions/reset-totp.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+trap '' SIGINT SIGTSTP SIGQUIT
+
 set -euo pipefail
 
 sudo tpm2-totp clean 2>/dev/null || true

--- a/config/vendor-functions/select-usb-drive-and-mount.sh
+++ b/config/vendor-functions/select-usb-drive-and-mount.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-# Requires sudo
+trap '' SIGINT SIGTSTP SIGQUIT
 
 set -euo pipefail
 

--- a/config/vendor-functions/set-clock.sh
+++ b/config/vendor-functions/set-clock.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+trap '' SIGINT SIGTSTP SIGQUIT
+
 set -euo pipefail
 declare -A TIMEZONES
 TIMEZONES["p"]="America/Los_Angeles"

--- a/config/vendor-functions/setup-boot-entry.sh
+++ b/config/vendor-functions/setup-boot-entry.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+trap '' SIGINT SIGTSTP SIGQUIT
+
 set -euo pipefail
 
 EFIDIR="/boot/efi/EFI/debian"

--- a/config/vendor-functions/show-key.sh
+++ b/config/vendor-functions/show-key.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+trap '' SIGINT SIGTSTP SIGQUIT
+
 set -euo pipefail
 
 : "${VX_CONFIG_ROOT:="/vx/config"}"

--- a/config/vendor-functions/show-system-hash.sh
+++ b/config/vendor-functions/show-system-hash.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+trap '' SIGINT SIGTSTP SIGQUIT
+
 set -euo pipefail
 
 : "${VX_METADATA_ROOT:="/vx/code"}"

--- a/config/vendor-functions/show-vendor-menu.sh
+++ b/config/vendor-functions/show-vendor-menu.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+trap '' SIGINT SIGTSTP SIGQUIT
+
 setfont /usr/share/consolefonts/Lat7-Terminus24x12.psf.gz
 
 set -euo pipefail

--- a/config/vendor-functions/start-screen-recording.sh
+++ b/config/vendor-functions/start-screen-recording.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+trap '' SIGINT SIGTSTP SIGQUIT
+
 set -euo pipefail
 
 USER="vx-ui" # Since we want to record the tty1 screen we have to act as the vx-ui user

--- a/config/vendor-functions/timedatectl
+++ b/config/vendor-functions/timedatectl
@@ -10,6 +10,8 @@
 # or when /etc/localtime is directly symlinked to a timezone file (the default linux setup)
 # then this script just calls the original timedatectl program.
 
+trap '' SIGINT SIGTSTP SIGQUIT
+
 ORIGINAL_TIMEDATECTL=/usr/bin/timedatectl
 TIMEZONE_DIRECTORY=/usr/share/zoneinfo
 

--- a/run-scripts/run-admin.sh
+++ b/run-scripts/run-admin.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+trap '' SIGINT SIGTSTP SIGQUIT
 set -euo pipefail
 
 # go to directory where this file is located

--- a/run-scripts/run-central-scan.sh
+++ b/run-scripts/run-central-scan.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+trap '' SIGINT SIGTSTP SIGQUIT
 set -euo pipefail
 
 # go to directory where this file is located

--- a/run-scripts/run-kiosk-browser-forever-and-log.sh
+++ b/run-scripts/run-kiosk-browser-forever-and-log.sh
@@ -1,5 +1,7 @@
 #!/usr/bin/env bash
 
+trap '' SIGINT SIGTSTP SIGQUIT
+
 set -euo pipefail
 
 # go to directory where this file is located

--- a/run-scripts/run-kiosk-browser.sh
+++ b/run-scripts/run-kiosk-browser.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+trap '' SIGINT SIGTSTP SIGQUIT
+
 set -euo pipefail
 
 URL=${1:-http://localhost:3000}

--- a/run-scripts/run-mark-scan.sh
+++ b/run-scripts/run-mark-scan.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+trap '' SIGINT SIGTSTP SIGQUIT
 set -euo pipefail
 
 # go to directory where this file is located

--- a/run-scripts/run-mark.sh
+++ b/run-scripts/run-mark.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+trap '' SIGINT SIGTSTP SIGQUIT
 set -euo pipefail
 
 # go to directory where this file is located

--- a/run-scripts/run-print.sh
+++ b/run-scripts/run-print.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+trap '' SIGINT SIGTSTP SIGQUIT
 set -euo pipefail
 
 # go to directory where this file is located

--- a/run-scripts/run-scan.sh
+++ b/run-scripts/run-scan.sh
@@ -1,5 +1,6 @@
 #!/usr/bin/env bash
 
+trap '' SIGINT SIGTSTP SIGQUIT
 set -euo pipefail
 
 # go to directory where this file is located


### PR DESCRIPTION
This PR blocks scripts from using various keyboard ctrl-<X> combinations from exiting to a console session. There will be follow-up work, for example: run scripts that were capturing a subset of these combos and the need to add a console session option to QA images, but this addresses the root issue of escaping from a shell during boot / app startup to a console session.