### PR TITLE
add console session option to qa images

### DIFF
--- a/config/vendor-functions/show-vendor-menu.sh
+++ b/config/vendor-functions/show-vendor-menu.sh
@@ -121,6 +121,9 @@ while true; do
 
     echo "${#CHOICES[@]}. Copy all Screen Recordings to USB"
     CHOICES+=('copy-recordings')
+
+    echo "${#CHOICES[@]}. Console Session"
+    CHOICES+=('console-session')
   fi
 
   echo "0. Reboot"
@@ -245,6 +248,10 @@ while true; do
     copy-recordings)
       sudo "${VX_FUNCTIONS_ROOT}/copy-recordings.sh"
       read -s -n 1
+    ;;
+
+    console-session)
+      exit 0;
     ;;
     
     reboot-to-bios)

--- a/config/vendor-functions/show-vendor-menu.sh
+++ b/config/vendor-functions/show-vendor-menu.sh
@@ -251,7 +251,11 @@ while true; do
     ;;
 
     console-session)
-      sh -c "/bin/bash"
+      if [[ $( cat "${VX_CONFIG_ROOT}/is-qa-image" 2>/dev/null || echo "0") = "1" ]]; then
+        sh -c "/bin/bash"
+      else
+        read -s -n 1
+      fi
     ;;
     
     reboot-to-bios)

--- a/config/vendor-functions/show-vendor-menu.sh
+++ b/config/vendor-functions/show-vendor-menu.sh
@@ -251,7 +251,7 @@ while true; do
     ;;
 
     console-session)
-      exit 0;
+      sh -c "/bin/bash"
     ;;
     
     reboot-to-bios)


### PR DESCRIPTION
Adds an option to the vendor menu to open a console session from the vendor menu in QA images to assist with troubleshooting.