### PR TITLE
use direct execution path rather than symlink for app run services

### DIFF
--- a/config/admin.service
+++ b/config/admin.service
@@ -8,7 +8,7 @@ Environment=VX_CONFIG_ROOT=/vx/config
 Environment=VX_METADATA_ROOT=/vx/code
 Environment=MODULE_SEMS_CONVERTER_WORKSPACE=/vx/data/module-sems-converter
 Environment=ADMIN_WORKSPACE=/vx/data/admin-service
-ExecStart=/bin/bash /vx/services/run-admin.sh
+ExecStart=/bin/bash /vx/code/run-admin.sh
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=votingworksapp

--- a/config/central-scan.service
+++ b/config/central-scan.service
@@ -7,7 +7,7 @@ User=vx-services
 Environment=VX_CONFIG_ROOT=/vx/config
 Environment=VX_METADATA_ROOT=/vx/code
 Environment=SCAN_WORKSPACE=/vx/data/module-scan
-ExecStart=/bin/bash /vx/services/run-central-scan.sh
+ExecStart=/bin/bash /vx/code/run-central-scan.sh
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=votingworksapp

--- a/config/mark-scan-controller-daemon.service
+++ b/config/mark-scan-controller-daemon.service
@@ -10,7 +10,7 @@ Type=simple
 User=vx-services
 Environment=VX_CONFIG_ROOT=/vx/config
 Environment=VX_METADATA_ROOT=/vx/code
-ExecStart=/bin/bash /vx/services/run-mark-scan-controller-daemon.sh
+ExecStart=/bin/bash /vx/code/run-mark-scan-controller-daemon.sh
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=votingworksapp

--- a/config/mark-scan-fai-100-daemon.service
+++ b/config/mark-scan-fai-100-daemon.service
@@ -11,7 +11,7 @@ User=vx-services
 Environment=VX_CONFIG_ROOT=/vx/config
 Environment=VX_METADATA_ROOT=/vx/code
 Environment=MARK_SCAN_WORKSPACE=/vx/data/module-mark-scan
-ExecStart=/bin/bash /vx/services/run-mark-scan-fai-100-daemon.sh
+ExecStart=/bin/bash /vx/code/run-mark-scan-fai-100-daemon.sh
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=votingworksapp

--- a/config/mark-scan-pat-daemon.service
+++ b/config/mark-scan-pat-daemon.service
@@ -10,7 +10,7 @@ Type=simple
 User=vx-services
 Environment=VX_CONFIG_ROOT=/vx/config
 Environment=VX_METADATA_ROOT=/vx/code
-ExecStart=/bin/bash /vx/services/run-mark-scan-pat-daemon.sh
+ExecStart=/bin/bash /vx/code/run-mark-scan-pat-daemon.sh
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=votingworksapp

--- a/config/mark-scan.service
+++ b/config/mark-scan.service
@@ -7,7 +7,7 @@ User=vx-services
 Environment=VX_CONFIG_ROOT=/vx/config
 Environment=VX_METADATA_ROOT=/vx/code
 Environment=MARK_SCAN_WORKSPACE=/vx/data/module-mark-scan
-ExecStart=/bin/bash /vx/services/run-mark-scan.sh
+ExecStart=/bin/bash /vx/code/run-mark-scan.sh
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=votingworksapp

--- a/config/mark.service
+++ b/config/mark.service
@@ -7,7 +7,7 @@ User=vx-services
 Environment=VX_CONFIG_ROOT=/vx/config
 Environment=VX_METADATA_ROOT=/vx/code
 Environment=MARK_WORKSPACE=/vx/data/module-mark
-ExecStart=/bin/bash /vx/services/run-mark.sh
+ExecStart=/bin/bash /vx/code/run-mark.sh
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=votingworksapp

--- a/config/print.service
+++ b/config/print.service
@@ -7,7 +7,7 @@ User=vx-services
 Environment=VX_CONFIG_ROOT=/vx/config
 Environment=VX_METADATA_ROOT=/vx/code
 Environment=PRINT_WORKSPACE=/vx/data/module-print
-ExecStart=/bin/bash /vx/services/run-print.sh
+ExecStart=/bin/bash /vx/code/run-print.sh
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=votingworksapp

--- a/config/scan.service
+++ b/config/scan.service
@@ -7,7 +7,7 @@ User=vx-services
 Environment=VX_CONFIG_ROOT=/vx/config
 Environment=VX_METADATA_ROOT=/vx/code
 Environment=SCAN_WORKSPACE=/vx/data/module-scan
-ExecStart=/bin/bash /vx/services/run-scan.sh
+ExecStart=/bin/bash /vx/code/run-scan.sh
 StandardOutput=syslog
 StandardError=syslog
 SyslogIdentifier=votingworksapp


### PR DESCRIPTION
Rather than using a symlink from the `/var` filesystem, e.g. `/vx/services/run-admin.sh`, call the appropriate application run script from the read-only `/vx/code/` filesystem, e.g. `/vx/code/run-admin.sh`. This follows the same pattern we use for running kiosk-browser.

EDIT: It may not be immediately obvious, but this PR _also_ helps address the potential for an attacker to modify symlinks to the `vxsuite` directory tree that would then be inherited by the running process. While the symlink currently remains, the run scripts set their execution context based on where the script lives, i.e. `/vx/code` (read-only) instead of `/vx/services` now. That means it also uses `/vx/code/vxsuite` rather than `/vx/services/vxsuite`, so even if the `/vx/services/vxsuite` link were modified, the system service would still operate in the context of the read-only `/vx/code/vxsuite` path. 