### PR TITLE
add node and rust updates to update-vxdev, update udev rule management, fix related update bug

### DIFF
--- a/vxdev/setup-vxdev-base-machine.sh
+++ b/vxdev/setup-vxdev-base-machine.sh
@@ -112,13 +112,9 @@ sudo usermod -aG adm vx
 sudo bash setup-scripts/setup-logging.sh
 
 # let vx manage printers
-sudo cp config/60-fujitsu-printer.rules /etc/udev/rules.d/
 sudo usermod -aG lpadmin vx
 
 # let vx scan
-sudo cp config/49-sane-missing-scanner.rules /etc/udev/rules.d/
-sudo cp config/50-pdi-scanner.rules /etc/udev/rules.d/
-sudo cp config/50-custom-scanner.rules /etc/udev/rules.d/
 sudo usermod -aG scanner vx
 sudo usermod -aG plugdev vx
 
@@ -126,7 +122,6 @@ sudo usermod -aG plugdev vx
 sudo getent group uinput || sudo groupadd uinput
 sudo getent group gpio || sudo groupadd gpio
 
-sudo cp config/50-uinput.rules /etc/udev/rules.d/
 sudo usermod -aG uinput vx-services
 
 sudo usermod -aG audio vx
@@ -135,7 +130,6 @@ sudo usermod -aG dialout vx-services
 sudo usermod -aG gpio vx-services
 sudo usermod -aG scanner vx-services
 sudo usermod -aG plugdev vx-services
-sudo cp config/50-gpio.rules /etc/udev/rules.d/
 
 sudo sh -c 'echo "uinput" >> /etc/modules-load.d/modules.conf'
 

--- a/vxdev/update-vxdev.sh
+++ b/vxdev/update-vxdev.sh
@@ -38,6 +38,13 @@ fi
 
 CHOICE=${CHOICES[$CHOICE_INDEX]}
 
+# Update Rust and Node to latest vxdev inventory versions
+cd /vx/code/vxsuite-build-system
+git checkout main > /dev/null 2>&1
+git pull > /dev/null
+source .virtualenv/ansible/bin/activate
+ansible-playbook -i inventories/vxdev-stable playbooks/trusted_build/node.yaml
+ansible-playbook -i inventories/vxdev-stable playbooks/trusted_build/rust.yaml
 
 cd /vx/code/vxsuite-complete-system
 
@@ -48,7 +55,6 @@ git pull > /dev/null
 # Update the configuration script and run it to fetch and apply any new updates to VxDev
 sudo cp vxdev/vxdev-configuration.sh /vx/scripts/.
 bash /vx/scripts/vxdev-configuration.sh
-
 
 FAVORITE_ICONS=''
 

--- a/vxdev/update-vxdev.sh
+++ b/vxdev/update-vxdev.sh
@@ -96,7 +96,4 @@ CHOICE="${CHOICE}" sudo -E sh -c 'echo "${CHOICE}" > /vx/config/machine-type'
 # vxdev daemons need this now, unlike setup_machine.sh, we use the CHOICE var
 MODEL_NAME="${CHOICE}" sudo -E sh -c 'echo "${MODEL_NAME}" > /vx/config/machine-model-name'
 
-# Update yourself as the very last step to avoid exec context issues
-sudo cp vxdev/update-vxdev.sh /vx/scripts/.
-
 echo "Done, this window will close in 3 seconds"

--- a/vxdev/update-vxdev.sh
+++ b/vxdev/update-vxdev.sh
@@ -96,5 +96,7 @@ CHOICE="${CHOICE}" sudo -E sh -c 'echo "${CHOICE}" > /vx/config/machine-type'
 # vxdev daemons need this now, unlike setup_machine.sh, we use the CHOICE var
 MODEL_NAME="${CHOICE}" sudo -E sh -c 'echo "${MODEL_NAME}" > /vx/config/machine-model-name'
 
+# Update yourself as the very last step to avoid exec context issues
+sudo cp vxdev/update-vxdev.sh /vx/scripts/.
 
 echo "Done, this window will close in 3 seconds"

--- a/vxdev/update-vxdev.sh
+++ b/vxdev/update-vxdev.sh
@@ -39,7 +39,7 @@ fi
 CHOICE=${CHOICES[$CHOICE_INDEX]}
 
 # Update Rust and Node to latest vxdev inventory versions
-cd /vx/code/vxsuite-build-system
+cd /home/vx/code/vxsuite-build-system
 git checkout main > /dev/null 2>&1
 git pull > /dev/null
 source .virtualenv/ansible/bin/activate

--- a/vxdev/vxdev-configuration.sh
+++ b/vxdev/vxdev-configuration.sh
@@ -15,7 +15,11 @@ sudo cp vxdev/votingworks-desktop.png /vx/.
 # Copy scripts and desktop files into the appropriate places
 sudo cp vxdev/set-hwta-env.sh /vx/scripts/.
 sudo cp vxdev/update-code.sh /vx/scripts/.
-#sudo cp vxdev/update-vxdev.sh /vx/scripts/.
+
+# Note: this cp + mv should prevent execution context errors when updating
+sudo cp vxdev/update-vxdev.sh /vx/scripts/update-vxdev.sh.tmp
+sudo mv /vx/scripts/update-vxdev.sh.tmp /vx/scripts/update-vxdev.sh
+
 sudo cp vxdev/update-code.desktop /usr/share/applications/.
 sudo cp vxdev/update-vxdev.desktop /usr/share/applications/.
 

--- a/vxdev/vxdev-configuration.sh
+++ b/vxdev/vxdev-configuration.sh
@@ -15,7 +15,7 @@ sudo cp vxdev/votingworks-desktop.png /vx/.
 # Copy scripts and desktop files into the appropriate places
 sudo cp vxdev/set-hwta-env.sh /vx/scripts/.
 sudo cp vxdev/update-code.sh /vx/scripts/.
-sudo cp vxdev/update-vxdev.sh /vx/scripts/.
+#sudo cp vxdev/update-vxdev.sh /vx/scripts/.
 sudo cp vxdev/update-code.desktop /usr/share/applications/.
 sudo cp vxdev/update-vxdev.desktop /usr/share/applications/.
 


### PR DESCRIPTION
This PR goes along with https://github.com/votingworks/vxsuite-build-system/pull/234

- udev rules are now managed via build-system
- updating vxdev now runs the `rust.yaml` and `node.yaml` playbooks with the `vxdev-stable` inventory to make version upgrades automatic
- resolved a painful execution context bug related to how `update-vxdev.sh` and `vxdev-configuration.sh` interact during an update