### PR TITLE
add multi user support to audio scripts

### DIFF
--- a/app-scripts/pactl.sh
+++ b/app-scripts/pactl.sh
@@ -11,9 +11,9 @@ if [[ $# -eq 0 ]]; then
   usage
 fi
 
-if id vx-ui 2>/dev/null; then
+if id vx-ui > /dev/null 2>&1; then
   user=vx-ui
-elif id vx 2>/dev/null; then
+elif id vx > /dev/null 2>&1; then
   user=vx
 else
   user=$( whoami )

--- a/app-scripts/pactl.sh
+++ b/app-scripts/pactl.sh
@@ -11,6 +11,14 @@ if [[ $# -eq 0 ]]; then
   usage
 fi
 
-vx_ui_id=$( id -u vx-ui )
+if id vx-ui 2>/dev/null; then
+  user=vx-ui
+elif id vx 2>/dev/null; then
+  user=vx
+else
+  user=$( whoami )
+fi
 
-sudo -u vx-ui XDG_RUNTIME_DIR=/run/user/${vx_ui_id} pactl "$@"
+userid=$( id -u ${user} )
+
+sudo -u $user XDG_RUNTIME_DIR=/run/user/${userid} pactl "$@"

--- a/app-scripts/paplay.sh
+++ b/app-scripts/paplay.sh
@@ -11,6 +11,14 @@ if [[ $# -eq 0 ]]; then
   usage
 fi
 
-vx_ui_id=$( id -u vx-ui )
+if id vx-ui > /dev/null 2>&1; then
+  user=vx-ui
+elif id vx > /dev/null 2>&1; then
+  user=vx
+else
+  user=$( whoami )
+fi
 
-sudo -u vx-ui XDG_RUNTIME_DIR=/run/user/${vx_ui_id} paplay "$@"
+userid=$( id -u ${user} )
+
+sudo -u $user XDG_RUNTIME_DIR=/run/user/${userid} paplay "$@"


### PR DESCRIPTION
In production, audio is played via the `vx-ui` user. In dev environments, the local user may differ, and the hardcoded path can cause the application to not play audio or crash. This checks for the expected `vx-ui` user, falls back to the `vx` user, and then ultimately falls back to the current user calling the script. 