### PR TITLE
add honeywell barcode reader udev rules

### DIFF
--- a/vxdev/setup-vxdev-base-machine.sh
+++ b/vxdev/setup-vxdev-base-machine.sh
@@ -111,6 +111,10 @@ sudo usermod -aG adm vx
 # Set up log config
 sudo bash setup-scripts/setup-logging.sh
 
+# honeywall barcode reader
+# TODO: move to build-system with the production update
+sudo cp config/65-honeywell-barcode-reader.rules /etc/udev/rules.d/
+
 # let vx manage printers
 sudo cp config/60-fujitsu-printer.rules /etc/udev/rules.d/
 sudo usermod -aG lpadmin vx


### PR DESCRIPTION
This PR adds the udev rules required to support the honeywell barcode reader, following the current production pattern. This should eventually migrate to a defined udev rule in build-system inventory definitions, but copying production is sufficient for now.