### PR TITLE
Use wrapper script to restrict logrotate args

### DIFF
--- a/config/sudoers
+++ b/config/sudoers
@@ -53,4 +53,4 @@ vx-services ALL=(root:ALL) NOPASSWD: /vx/code/app-scripts/paplay.sh
 vx-services ALL=(root:ALL) NOPASSWD: /vx/code/app-scripts/set-usb-port-status.sh
 vx-ui ALL=(root:ALL) NOPASSWD: /vx/code/config/vendor-functions/timedatectl
 vx-ui ALL=(root:ALL) NOPASSWD: /usr/bin/brightnessctl
-vx-ui ALL=(root:ALL) NOPASSWD: /sbin/logrotate
+vx-ui ALL=(root:ALL) NOPASSWD: /vx/code/config/vendor-functions/rotate-logs.sh

--- a/config/sudoers-for-dev
+++ b/config/sudoers-for-dev
@@ -54,4 +54,4 @@ vx-services ALL=(root:ALL) NOPASSWD: /vx/code/app-scripts/paplay.sh
 vx-services ALL=(root:ALL) NOPASSWD: /vx/code/app-scripts/set-usb-port-status.sh
 vx-ui ALL=(root:ALL) NOPASSWD: /vx/code/config/vendor-functions/timedatectl
 vx-ui ALL=(root:ALL) NOPASSWD: /usr/bin/brightnessctl
-vx-ui ALL=(root:ALL) NOPASSWD: /sbin/logrotate
+vx-ui ALL=(root:ALL) NOPASSWD: /vx/code/config/vendor-functions/rotate-logs.sh

--- a/config/vendor-functions/rotate-logs.sh
+++ b/config/vendor-functions/rotate-logs.sh
@@ -1,0 +1,7 @@
+#!/usr/bin/env bash
+
+trap '' SIGINT SIGTSTP SIGQUIT
+
+set -euo pipefail
+
+/sbin/logrotate --force /etc/vx-logs.logrotate

--- a/run-scripts/run-kiosk-browser-forever-and-log.sh
+++ b/run-scripts/run-kiosk-browser-forever-and-log.sh
@@ -10,7 +10,7 @@ cd "$(dirname "$0")"
 # rotate vx-logs.log if necessary
 # always return true on failure since logs dont always need rotating
 # but logrotate throws an error code
-sudo /sbin/logrotate --force /etc/vx-logs.logrotate || true
+sudo /vx/code/config/vendor-functions/rotate-logs.sh || true
 
 # configuration information
 CONFIG=${VX_CONFIG_ROOT:-./config}


### PR DESCRIPTION
A little more sudoers cleanup. Here, I'm removing the sudoers entry that grants access to `/sbin/logrotate` with unrestricted args and replacing it with an entry that grants access to a script that performs our exact log rotation command.

Committed `config/vendor-functions/rotate-logs.sh` with executable permissions. `setup-machine.sh` may already handle setting executable permissions, but all other scripts in `config/vendor-functions` also already have this bit set so I'm matching for consistency.

I'll also acknowledge that `config/vendor-functions` isn't the right directory name here as this is a vx-ui action, not a vx-vendor action. But this is our designated location for these scripts, and we already have other scripts in there specific to vx-ui. We can rename later.