### PR TITLE
Remove vx-ui's ability to write to /vx/config/app-flags

### DIFF
--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -278,13 +278,11 @@ sudo chown -R vx-services:vx-services /var/vx/data
 sudo chmod -R u=rwX /var/vx/data
 sudo chmod -R go-rwX /var/vx/data
 
-# Config is writable by the vx-vendor user and readable/executable by all vx-* users, with the
-# exception of the app-flags subdirectory and /vx/config/openssl.cnf, which are special-cased to be
-# writable by all vx-* users
+# Config is writable by the vx-vendor user and readable/executable by all vx-* users. Other users
+# can also write config as root via scripts made accessible via sudoers.
 sudo chown -R vx-vendor:vx-group /var/vx/config
 sudo chmod -R u=rwX /var/vx/config
 sudo chmod -R g=rX /var/vx/config
-sudo chmod -R g=rwX /var/vx/config/app-flags
 sudo chmod -R o-rwX /var/vx/config
 
 # Prep the symlink structure for swapping of the default OpenSSL config file in a way that doesn't


### PR DESCRIPTION
I added `sudo chmod -R g=rwX /var/vx/config/app-flags` to `setup-machine.sh` long ago to allow `vx-services` to write the flag file necessary to boot to the vendor menu. This knowingly also gave `vx-ui` the ability to write that file: https://github.com/votingworks/vxsuite-complete-system/pull/395#discussion_r1766142342

But upon review, `vx-services` writes the flag file as root via a script made accessible via sudoers: https://github.com/votingworks/vxsuite/blob/04bda12aea6bb24868461ec13509ccce4129766b/libs/backend/src/system_call/reboot_to_vendor_menu.ts#L34-L37 + https://github.com/votingworks/vxsuite-complete-system/blob/f9866e748c39791400b097fb0eccc35117251d36/config/sudoers#L49

So giving `vx-group` (i.e., both `vx-services` and `vx-ui`) permission to write to `/vx/config/app-flags` isn't actually necessary. By removing the `sudo chmod -R g=rwX /var/vx/config/app-flags` line, we can remove `vx-ui`'s ability to write to `/vx/config/app-flags`. An improvement from a defense-in-depth perspective.