### PR TITLE
Add VxPrint Cino S680 barcode scanner config

### DIFF
--- a/config/70-cino-s680-plugdev-usb.rules
+++ b/config/70-cino-s680-plugdev-usb.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="usb", MODE="0660", GROUP="plugdev", ATTRS{idVendor}=="1fbb", ATTRS{idProduct}=="3850"

--- a/config/99-cino-s680-dialout-tty.rules
+++ b/config/99-cino-s680-dialout-tty.rules
@@ -1,0 +1,1 @@
+SUBSYSTEM=="tty", ACTION=="add", KERNEL=="ttyACM[0-9]*", ATTRS{idVendor}=="1fbb", ATTRS{idProduct}=="3850", MODE="0660", GROUP="dialout", SYMLINK+="barcode_scanner"

--- a/config/barcode-scanner-daemon.service
+++ b/config/barcode-scanner-daemon.service
@@ -1,0 +1,19 @@
+[Unit]
+Description=VotingWorks daemon to support a barcode scanner
+StartLimitIntervalSec=300
+StartLimitBurst=10
+
+[Service]
+Restart=on-failure
+RestartSec=10
+Type=simple
+User=vx-services
+Environment=VX_CONFIG_ROOT=/vx/config
+Environment=VX_METADATA_ROOT=/vx/code
+ExecStart=/bin/bash /vx/services/run-barcode-scanner-daemon.sh
+StandardOutput=syslog
+StandardError=syslog
+SyslogIdentifier=votingworksapp
+
+[Install]
+WantedBy=multi-user.target

--- a/run-scripts/run-barcode-scanner-daemon.sh
+++ b/run-scripts/run-barcode-scanner-daemon.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+# go to directory where this file is located
+cd "$(dirname "$0")"
+
+# configuration information
+CONFIG=${VX_CONFIG_ROOT:-./config}
+METADATA=${VX_METADATA_ROOT:-./}
+source ${CONFIG}/read-vx-machine-config.sh
+
+(trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/print/barcode-scanner-daemon run) | logger -S 4096 --tag votingworksapp

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -168,6 +168,12 @@ then
     sudo cp config/65-honeywell-barcode-reader.rules /etc/udev/rules.d/
 fi
 
+if [ "${CHOICE}" == "print" ]
+then
+    sudo cp config/70-cino-s680-plugdev-usb.rules /etc/udev/rules.d/
+    sudo cp config/99-cino-s680-dialout-tty.rules /etc/udev/rules.d/
+fi
+
 echo "Setting up the code"
 sudo rsync -avz build/${CHOICE}/ /vx/code/
 
@@ -357,6 +363,16 @@ sudo cp config/${CHOICE}.service /etc/systemd/system/
 sudo chmod 644 /etc/systemd/system/${CHOICE}.service
 sudo systemctl enable ${CHOICE}.service
 sudo systemctl start ${CHOICE}.service
+
+# print requires a barcode scanner daemon
+if [[ "${CHOICE}" == "print" ]]; then
+  sudo cp config/barcode-scanner-daemon.service /etc/systemd/system/
+  sudo cp run-scripts/run-barcode-scanner-daemon.sh /vx/code/
+  sudo chmod 644 /etc/systemd/system/barcode-scanner-daemon.service
+  sudo ln -s /vx/code/run-barcode-scanner-daemon.sh /vx/services/run-barcode-scanner-daemon.sh
+  sudo systemctl enable barcode-scanner-daemon.service
+  sudo systemctl start barcode-scanner-daemon.service
+fi
 
 # mark-scan requires additional service daemons
 if [[ "${CHOICE}" == "mark-scan" ]]; then

--- a/vxdev/setup-vxdev-base-machine.sh
+++ b/vxdev/setup-vxdev-base-machine.sh
@@ -115,12 +115,19 @@ sudo bash setup-scripts/setup-logging.sh
 # TODO: move to build-system with the production update
 sudo cp config/65-honeywell-barcode-reader.rules /etc/udev/rules.d/
 
+# cino barcode scanner
+sudo cp config/70-cino-s680-plugdev-usb.rules /etc/udev/rules.d/
+sudo cp config/99-cino-s680-dialout-tty.rules /etc/udev/rules.d/
+
 # let vx manage printers
 sudo usermod -aG lpadmin vx
 
 # let vx scan
 sudo usermod -aG scanner vx
+
+# let vx use serial devices
 sudo usermod -aG plugdev vx
+sudo usermod -aG dialout vx
 
 # mark-scan groups and permissions
 sudo getent group uinput || sudo groupadd uinput


### PR DESCRIPTION
Config and script changes necessary for running the Cino S680 barcode scanner on VxPrint. Copied from VxPollBook's config changes: https://github.com/votingworks/vxsuite-build-system/pull/207