### PR TITLE
Always include new machine types in setup-machine.sh prompt

### DIFF
--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -27,21 +27,17 @@ echo "${#CHOICES[@]}. VxCentralScan"
 CHOICES+=('central-scan')
 MODEL_NAMES+=('VxCentralScan')
 
-if [[ "${1:-}" == "--include-new-machines" ]]; then
-    echo "${#CHOICES[@]}. VxMark"
-    CHOICES+=('mark')
-    MODEL_NAMES+=('VxMark')
-fi
+echo "${#CHOICES[@]}. VxMark"
+CHOICES+=('mark')
+MODEL_NAMES+=('VxMark')
 
 echo "${#CHOICES[@]}. VxMarkScan"
 CHOICES+=('mark-scan')
 MODEL_NAMES+=('VxMarkScan')
 
-if [[ "${1:-}" == "--include-new-machines" ]]; then
-    echo "${#CHOICES[@]}. VxPrint"
-    CHOICES+=('print')
-    MODEL_NAMES+=('VxPrint')
-fi
+echo "${#CHOICES[@]}. VxPrint"
+CHOICES+=('print')
+MODEL_NAMES+=('VxPrint')
 
 echo "${#CHOICES[@]}. VxScan"
 CHOICES+=('scan')


### PR DESCRIPTION
This gate was only needed to keep the new machine types (VxMark, VxPrint) hidden during v4.0 Trusted Builds with SLI. Now that we're officially certifying these components, no reason to ever hide them from the list of machine types.