### PR TITLE
Bandaid: Account for double mounting (and avoid missing CSRs during cert dance)

### DIFF
--- a/app-scripts/unmount-usb.sh
+++ b/app-scripts/unmount-usb.sh
@@ -12,4 +12,5 @@ if ! [[ $# -eq 0 ]]; then
 fi
 
 MOUNTPOINT=/media/vx/usb-drive
+sync $MOUNTPOINT
 umount $MOUNTPOINT

--- a/config/vendor-functions/copy-logs.sh
+++ b/config/vendor-functions/copy-logs.sh
@@ -35,7 +35,9 @@ cp -r /var/log/votingworks/vx-logs.log* "$DIRECTORY"
 # unmount the USB stick to make sure it's all written to disk
 echo "Saving logs to USB drive..."
 sync $MOUNTPOINT
-sudo /vx/code/app-scripts/unmount-usb.sh
+if [[ $MOUNTPOINT == "/media/vx/usb-drive" ]]; then
+    sudo /vx/code/app-scripts/unmount-usb.sh
+fi
 
 echo "All done. You may remove the USB drive."
 echo "Type Enter to continue."


### PR DESCRIPTION
## Overview

Our main app has auto-mounting logic and also now uses different mount points (in preparation for the need to support multiple USB drives) than our long standard single /media/vx/usb-drive mount point.

There remain a few vendor function scripts in vxsuite-complete-system, though, that still use the old mount point, the most notable being the cert dance script.

Put two and two together and you end up with situations where a USB drive is double mounted. One consequence of this appears to be that data isn't always flushed as we'd expect. Even when we unmount a USB drive, another mount point may remain and delay flushing.

Some well placed sync's seem to be doing the trick. Note that we're using sync and not sync -f (i.e. sync everything, not just the one identified file system). Empirically, sync -f isn't always working. Makes sense in a world of symlinks and multiple mount points. Hard to know which file system sync -f is gonna target. **Edit: See some further clarification on sync commands in https://github.com/votingworks/vxsuite-complete-system/pull/537**

----

I first noticed this when trying to complete the cert dance and not being able to find any CSRs on the USB drive. I later found that waiting a couple of seconds before removing the drive helped guarantee that the CSRs were actually there. This led me down this path. After this change, the CSRs should be reliably there.

The new app auto-mounting logic also had an effect on the vendor copy logs function. That's explained in a comment below.

Long-term, we should either prevent the app's auto-mounting logic from affecting vendor actions, have vendor actions use the same scripts as the app, or some combo of the two.

## Testing

Tested manually with images