### PR TITLE
Use sync instead of sync $MOUNTPOINT

### DIFF
--- a/app-scripts/unmount-usb.sh
+++ b/app-scripts/unmount-usb.sh
@@ -12,5 +12,17 @@ if ! [[ $# -eq 0 ]]; then
 fi
 
 MOUNTPOINT=/media/vx/usb-drive
-sync $MOUNTPOINT
+
+# Pull out all the stops to make sure that data is flushed.
+#
+# The app is now auto-mounting USB drives at device-specific paths, e.g.,
+# /media/vx/usb-drive-sdb1. Vendor functions haven't been migrated to that
+# system yet and still perform their own mounting at /media/vx/usb-drive. This
+# means that, in the context of vendor functions like the cert dance, USB
+# drives can be double mounted. While an unmount will typically flush data,
+# it may not do so when a drive is still mounted at some other location. We
+# accordingly explicitly flush.
+#
+sync # Flush across all locations rather than using sync -f $MOUNTPOINT
 umount $MOUNTPOINT
+sleep 2 # Shouldn't be necessary but throwing it in for good measure

--- a/config/vendor-functions/copy-logs.sh
+++ b/config/vendor-functions/copy-logs.sh
@@ -34,7 +34,7 @@ cp -r /var/log/votingworks/vx-logs.log* "$DIRECTORY"
 
 # unmount the USB stick to make sure it's all written to disk
 echo "Saving logs to USB drive..."
-sync $MOUNTPOINT
+sync
 if [[ $MOUNTPOINT == "/media/vx/usb-drive" ]]; then
     sudo /vx/code/app-scripts/unmount-usb.sh
 fi

--- a/config/vendor-functions/copy-recordings.sh
+++ b/config/vendor-functions/copy-recordings.sh
@@ -32,7 +32,7 @@ sudo sh -c "cp /var/vx/ui/screen-recordings/*.mp4 $DIRECTORY"
 
 # unmount the USB stick to make sure it's all written to disk
 echo "Saving to USB drive and unmounting..."
-sync $MOUNTPOINT
+sync
 sudo /vx/code/app-scripts/unmount-usb.sh
 
 echo "All done. You may remove the USB drive."


### PR DESCRIPTION
A quick follow-up to https://github.com/votingworks/vxsuite-complete-system/pull/536. I had a slight misunderstanding when opening that PR. There are three permutations of sync commands.
1. sync
2. sync -f PATH
3. sync PATH

@amcmanus and I were discussing how `sync -f PATH` may behave in unspecified ways when we have symlinks and multiple mount points for a USB drive. But `sync` will flush across all locations. I mistakenly switched to the intermediate `sync PATH` which appears to be the most narrowly scoped option. It only flushes the one item at `PATH` and nothing else. If that's a directory, that may not even include the files in the directory.

My testing has been quite haphazard here.  In one test, I found that data was not synced after `sync -f PATH` but was after `sync PATH`. But that my just have been a fluke. The first test was on a prod image and the second on a QA image. Ultimately, the only option that feels truly safe in this symlink, multiple-mount-point context is `sync`. I also added a sleep for good measure since this code is so one-off and speed is not a priority.