### PR TITLE
Avoid usblp log spam on VxMark and VxPrint

### DIFF
--- a/config/modprobe.d/60-fujitsu-printer.conf
+++ b/config/modprobe.d/60-fujitsu-printer.conf
@@ -1,1 +1,0 @@
-blacklist usblp

--- a/config/modprobe.d/60-usblp.conf
+++ b/config/modprobe.d/60-usblp.conf
@@ -1,0 +1,6 @@
+# VxSuite prints via CUPS, which claims the printer's USB interface and
+# detaches the kernel usblp driver. When usblp is auto-loaded, each CUPS
+# printer status poll triggers a usblp detach/reattach cycle, flooding the
+# logs. Blocking usblp lets CUPS own the device cleanly and eliminates the
+# churn. usblp is not otherwise used.
+blacklist usblp

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -134,9 +134,9 @@ sudo cp config/apparmor.d/usr.sbin.cupsd /etc/apparmor.d/
 # copy any modprobe configs we might use
 sudo cp config/modprobe.d/10-i915.conf /etc/modprobe.d/
 sudo cp config/modprobe.d/50-bluetooth.conf /etc/modprobe.d/
-if [ "${CHOICE}" == "scan" ]
+if [ "${CHOICE}" != "mark-scan" ] # Likely safe for VxMarkScan but I don't have hardware to test
 then
-    sudo cp config/modprobe.d/60-fujitsu-printer.conf /etc/modprobe.d/
+    sudo cp config/modprobe.d/60-usblp.conf /etc/modprobe.d/
 fi
 
 # On non-vsap systems, there can be varying levels of screen flickering


### PR DESCRIPTION
## Overview

VxMark and VxPrint have an extreme amount of log spam of the following form:

```
{"timeLogWritten":"2026-07-09T21:51:01.236447-04:00", "host":"VotingWorks", "message":"usblp3: removed", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2026-07-09T21:51:01.236566-04:00", "host":"VotingWorks", "message":"usblp 3-1.2:1.0: usblp3: USB Bidirectional printer dev 6 if 0 alt 0 proto 2 vid 0x03F0 pid 0x0274", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2026-07-09T21:51:01.400869-04:00", "host":"VotingWorks", "message":"usblp3: removed", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2026-07-09T21:51:01.400950-04:00", "host":"VotingWorks", "message":"usblp 3-1.2:1.0: usblp3: USB Bidirectional printer dev 6 if 0 alt 0 proto 2 vid 0x03F0 pid 0x0274", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2026-07-09T21:51:01.560076-04:00", "host":"VotingWorks", "message":"usblp3: removed", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
{"timeLogWritten":"2026-07-09T21:51:01.560152-04:00", "host":"VotingWorks", "message":"usblp 3-1.2:1.0: usblp3: USB Bidirectional printer dev 6 if 0 alt 0 proto 2 vid 0x03F0 pid 0x0274", "source": "system", "eventId": "usb-device-change-detected", "eventType": "system-status", "user": "system", "disposition": "na"}
```

Repeating the code comment

> VxSuite prints via CUPS, which claims the printer's USB interface and
> detaches the kernel usblp driver. When usblp is auto-loaded, each CUPS
> printer status poll triggers a usblp detach/reattach cycle, flooding the
> logs. Blocking usblp lets CUPS own the device cleanly and eliminates the
> churn. usblp is not otherwise used.

We're accomplishing this by repeating the method already used by VxScan, a modprobe config file. We're taking that file and applying it to all machines, not just VxScan.

In terms of why the log spam only exists on VxMark and VxPrint and not the other machines, they're the only two machines that poll printer status and are meant to be consistently connected to a printer. (VxScan polls printer status too but already has the usblp block in place.)

## Testing

Tested on a VxMark QA image. Reproed the log spam. Then updated the config and saw the log spam go away. Confirmed that printing still works after the edit.