### PR TITLE
Remove the build sudoers drop-in during vx-cleanup

### DIFF
--- a/config/vx-cleanup.sh
+++ b/config/vx-cleanup.sh
@@ -10,6 +10,12 @@ LVM_DEVICE_PATH="/dev/Vx-vg/vxbuild"
 /usr/bin/rm -f /var/log/syslog
 /usr/bin/rm -f /var/log/votingworks/*
 
+# Base debian images give the vx user passwordless sudo so the build can run
+# unattended; it must not ship in a machine image. (Harmless once
+# setup-machine replaces /etc/sudoers with a config that has no includedir,
+# but removed here so the file never reaches a built image at all.)
+/usr/bin/rm -f /etc/sudoers.d/99-vxbuild
+
 # fstrim the build volume. It must be mounted or space won't
 # be reclaimed
 # unmount the LVM build volume


### PR DESCRIPTION
Removes passwordless sudo change for vx users for build steps made in: https://github.com/votingworks/vxsuite-build-system/pull/260