### PR TITLE
Changes to support scripted builds

### DIFF
--- a/config/vx-cleanup.sh
+++ b/config/vx-cleanup.sh
@@ -10,6 +10,12 @@ LVM_DEVICE_PATH="/dev/Vx-vg/vxbuild"
 /usr/bin/rm -f /var/log/syslog
 /usr/bin/rm -f /var/log/votingworks/*
 
+# Base debian images give the vx user passwordless sudo so the build can run
+# unattended; it must not ship in a machine image. (Harmless once
+# setup-machine replaces /etc/sudoers with a config that has no includedir,
+# but removed here so the file never reaches a built image at all.)
+/usr/bin/rm -f /etc/sudoers.d/99-vxbuild
+
 # fstrim the build volume. It must be mounted or space won't
 # be reclaimed
 # unmount the LVM build volume

--- a/config/vx-cleanup.sh
+++ b/config/vx-cleanup.sh
@@ -16,6 +16,12 @@ LVM_DEVICE_PATH="/dev/Vx-vg/vxbuild"
 # but removed here so the file never reaches a built image at all.)
 /usr/bin/rm -f /etc/sudoers.d/99-vxbuild
 
+# Artifacts of an automated build (build-vx-image.sh): the marker that lets
+# its in-VM finalize script confirm it is running in a build VM, and a shim
+# that makes `logname` work for build scripts run outside a login session.
+/usr/bin/rm -f /etc/vx-build-vm
+/usr/bin/rm -rf /usr/local/lib/vxbuild-shim
+
 # fstrim the build volume. It must be mounted or space won't
 # be reclaimed
 # unmount the LVM build volume

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -495,6 +495,12 @@ sudo chown -R vx-ui:vx-ui ${vx_ui_homedir}/.config/pulse
 # Remove git
 sudo apt remove -y git > /dev/null 2>&1 || true
 
+# Base debian images include openssh-server so that image builds can be
+# driven over ssh; it must never ship in a machine image. Purging here (with
+# a live system, before the lockdown below) covers manual and automated
+# builds alike. No-op if the base image did not include it.
+sudo apt-get -y purge openssh-server openssh-sftp-server > /dev/null
+
 echo "Successfully setup machine."
 
 # now we remove permissions, reset passwords, and ready for production.

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -11,6 +11,30 @@ set -euo pipefail
 
 export PATH=${PATH}:/sbin/
 
+# Non-interactive support: each interactive prompt below can be answered via
+# a command line argument instead, for automated builds.
+VX_MACHINE_TYPE=""
+VX_IS_QA_IMAGE=""
+VX_IS_RELEASE_IMAGE=""
+VX_VENDOR_PASSWORD=""
+VX_SKIP_SCHEDULED_REBOOT=0
+while [[ $# -gt 0 ]]; do
+    case "$1" in
+        --machine-type)          VX_MACHINE_TYPE="$2"; shift 2 ;;
+        --qa-image)              VX_IS_QA_IMAGE="y"; shift ;;
+        --prod-image)            VX_IS_QA_IMAGE="n"; shift ;;
+        --release-image)         VX_IS_RELEASE_IMAGE="y"; shift ;;
+        --vendor-password)       VX_VENDOR_PASSWORD="$2"; shift 2 ;;
+        --skip-scheduled-reboot) VX_SKIP_SCHEDULED_REBOOT=1; shift ;;
+        *) echo "Unknown option: $1" >&2; exit 1 ;;
+    esac
+done
+# A scripted prod image (--prod-image) that didn't pass --release-image
+# defaults to non-release; interactive runs still get the prompt.
+if [[ "${VX_IS_QA_IMAGE}" == "n" && -z "${VX_IS_RELEASE_IMAGE}" ]]; then
+    VX_IS_RELEASE_IMAGE="n"
+fi
+
 # which kind of machine are we setting up?
 echo "Welcome to VxSuite. THIS IS A DESTRUCTIVE SCRIPT. Ctrl-C right now if you don't know for sure what you're doing."
 echo "Which machine are we building today?"
@@ -44,17 +68,14 @@ CHOICES+=('scan')
 MODEL_NAMES+=('VxScan')
 
 echo
-# Each prompt below can be answered non-interactively via an environment
-# variable (VX_MACHINE_TYPE, VX_IS_QA_IMAGE, VX_IS_RELEASE_IMAGE,
-# VX_VENDOR_PASSWORD) to support automated builds.
-if [[ -n "${VX_MACHINE_TYPE:-}" ]]; then
+if [[ -n "${VX_MACHINE_TYPE}" ]]; then
     CHOICE_INDEX=0
     for i in "${!CHOICES[@]}"; do
         if [[ "${CHOICES[$i]}" == "${VX_MACHINE_TYPE}" ]]; then
             CHOICE_INDEX=$i
         fi
     done
-    echo "Machine type set via VX_MACHINE_TYPE: ${VX_MACHINE_TYPE}"
+    echo "Machine type set via --machine-type: ${VX_MACHINE_TYPE}"
 else
     read -p "Select machine: " CHOICE_INDEX
 fi
@@ -71,9 +92,9 @@ MODEL_NAME=${MODEL_NAMES[$CHOICE_INDEX]}
 echo "Excellent, let's set up ${CHOICE}."
 
 echo
-if [[ -n "${VX_IS_QA_IMAGE:-}" ]]; then
+if [[ -n "${VX_IS_QA_IMAGE}" ]]; then
     qa_image_flag="${VX_IS_QA_IMAGE}"
-    echo "QA image flag set via VX_IS_QA_IMAGE: ${VX_IS_QA_IMAGE}"
+    echo "QA image flag set via --qa-image/--prod-image: ${VX_IS_QA_IMAGE}"
 else
     read -p "Is this image for QA, where you want sudo privileges, terminal access via TTY2, and the ability to record screengrabs? [y/N] " qa_image_flag
 fi
@@ -88,15 +109,15 @@ else
     IS_QA_IMAGE=0
     echo "Ok, creating a production image. No sudo privileges for anyone!"
     echo
-    if [[ -n "${VX_IS_RELEASE_IMAGE:-}" ]]; then
+    if [[ -n "${VX_IS_RELEASE_IMAGE}" ]]; then
         release_image_flag="${VX_IS_RELEASE_IMAGE}"
         confirm_release_image_flag="${VX_IS_RELEASE_IMAGE}"
-        echo "Release image flag set via VX_IS_RELEASE_IMAGE: ${VX_IS_RELEASE_IMAGE}"
+        echo "Release image flag set via --release-image: ${VX_IS_RELEASE_IMAGE}"
     else
         read -p "Is this additionally an official release image? [y/N] " release_image_flag
     fi
     if [[ "${release_image_flag}" == 'y' || "${release_image_flag}" == 'Y' ]]; then
-        [[ -n "${VX_IS_RELEASE_IMAGE:-}" ]] || read -p "Are you sure? [y/N] " confirm_release_image_flag
+        [[ -n "${VX_IS_RELEASE_IMAGE}" ]] || read -p "Are you sure? [y/N] " confirm_release_image_flag
         if [[ "${confirm_release_image_flag}" == 'y' || "${confirm_release_image_flag}" == 'Y' ]]; then
             IS_RELEASE_IMAGE=1
             VERSION="$(< VERSION)"
@@ -109,11 +130,11 @@ else
     fi
     echo
     echo "Next, we need to set a password for the vx-vendor user."
-    if [[ -n "${VX_VENDOR_PASSWORD:-}" ]]; then
+    if [[ -n "${VX_VENDOR_PASSWORD}" ]]; then
         VENDOR_PASSWORD="${VX_VENDOR_PASSWORD}"
-        echo "vx-vendor password set via VX_VENDOR_PASSWORD."
+        echo "vx-vendor password set via --vendor-password."
     fi
-    while [[ -z "${VX_VENDOR_PASSWORD:-}" ]]; do
+    while [[ -z "${VX_VENDOR_PASSWORD}" ]]; do
         read -s -p "Set vx-vendor password: " VENDOR_PASSWORD
         echo
         read -s -p "Confirm vx-vendor password: " CONFIRM_PASSWORD
@@ -485,10 +506,10 @@ USER=$(whoami)
 
 # We need to schedule a reboot since the vx user will no longer have sudo privileges. 
 # One minute is the shortest option, and that's plenty of time for final steps.
-# Automated builds set VX_SKIP_SCHEDULED_REBOOT and manage shutdown themselves
+# Automated builds pass --skip-scheduled-reboot and manage shutdown themselves
 # (the scheduled reboot can otherwise fire before an automation wrapper's
 # post-setup-machine steps finish).
-if [[ -z "${VX_SKIP_SCHEDULED_REBOOT:-}" ]]; then
+if [[ "${VX_SKIP_SCHEDULED_REBOOT}" != "1" ]]; then
     sudo shutdown --no-wall -r +1
 fi
 

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -485,7 +485,12 @@ USER=$(whoami)
 
 # We need to schedule a reboot since the vx user will no longer have sudo privileges. 
 # One minute is the shortest option, and that's plenty of time for final steps.
-sudo shutdown --no-wall -r +1
+# Automated builds set VX_SKIP_SCHEDULED_REBOOT and manage shutdown themselves
+# (the scheduled reboot can otherwise fire before an automation wrapper's
+# post-setup-machine steps finish).
+if [[ -z "${VX_SKIP_SCHEDULED_REBOOT:-}" ]]; then
+    sudo shutdown --no-wall -r +1
+fi
 
 # disable all passwords
 sudo passwd -l root

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -44,7 +44,20 @@ CHOICES+=('scan')
 MODEL_NAMES+=('VxScan')
 
 echo
-read -p "Select machine: " CHOICE_INDEX
+# Each prompt below can be answered non-interactively via an environment
+# variable (VX_MACHINE_TYPE, VX_IS_QA_IMAGE, VX_IS_RELEASE_IMAGE,
+# VX_VENDOR_PASSWORD) to support automated builds.
+if [[ -n "${VX_MACHINE_TYPE:-}" ]]; then
+    CHOICE_INDEX=0
+    for i in "${!CHOICES[@]}"; do
+        if [[ "${CHOICES[$i]}" == "${VX_MACHINE_TYPE}" ]]; then
+            CHOICE_INDEX=$i
+        fi
+    done
+    echo "Machine type set via VX_MACHINE_TYPE: ${VX_MACHINE_TYPE}"
+else
+    read -p "Select machine: " CHOICE_INDEX
+fi
 
 if [ "${CHOICE_INDEX}" -ge "${#CHOICES[@]}" ] || [ "${CHOICE_INDEX}" -lt 1 ]
 then
@@ -58,7 +71,12 @@ MODEL_NAME=${MODEL_NAMES[$CHOICE_INDEX]}
 echo "Excellent, let's set up ${CHOICE}."
 
 echo
-read -p "Is this image for QA, where you want sudo privileges, terminal access via TTY2, and the ability to record screengrabs? [y/N] " qa_image_flag
+if [[ -n "${VX_IS_QA_IMAGE:-}" ]]; then
+    qa_image_flag="${VX_IS_QA_IMAGE}"
+    echo "QA image flag set via VX_IS_QA_IMAGE: ${VX_IS_QA_IMAGE}"
+else
+    read -p "Is this image for QA, where you want sudo privileges, terminal access via TTY2, and the ability to record screengrabs? [y/N] " qa_image_flag
+fi
 
 IS_RELEASE_IMAGE=0
 if [[ $qa_image_flag == 'y' || $qa_image_flag == 'Y' ]]; then
@@ -70,9 +88,15 @@ else
     IS_QA_IMAGE=0
     echo "Ok, creating a production image. No sudo privileges for anyone!"
     echo
-    read -p "Is this additionally an official release image? [y/N] " release_image_flag
+    if [[ -n "${VX_IS_RELEASE_IMAGE:-}" ]]; then
+        release_image_flag="${VX_IS_RELEASE_IMAGE}"
+        confirm_release_image_flag="${VX_IS_RELEASE_IMAGE}"
+        echo "Release image flag set via VX_IS_RELEASE_IMAGE: ${VX_IS_RELEASE_IMAGE}"
+    else
+        read -p "Is this additionally an official release image? [y/N] " release_image_flag
+    fi
     if [[ "${release_image_flag}" == 'y' || "${release_image_flag}" == 'Y' ]]; then
-        read -p "Are you sure? [y/N] " confirm_release_image_flag
+        [[ -n "${VX_IS_RELEASE_IMAGE:-}" ]] || read -p "Are you sure? [y/N] " confirm_release_image_flag
         if [[ "${confirm_release_image_flag}" == 'y' || "${confirm_release_image_flag}" == 'Y' ]]; then
             IS_RELEASE_IMAGE=1
             VERSION="$(< VERSION)"
@@ -85,7 +109,11 @@ else
     fi
     echo
     echo "Next, we need to set a password for the vx-vendor user."
-    while true; do
+    if [[ -n "${VX_VENDOR_PASSWORD:-}" ]]; then
+        VENDOR_PASSWORD="${VX_VENDOR_PASSWORD}"
+        echo "vx-vendor password set via VX_VENDOR_PASSWORD."
+    fi
+    while [[ -z "${VX_VENDOR_PASSWORD:-}" ]]; do
         read -s -p "Set vx-vendor password: " VENDOR_PASSWORD
         echo
         read -s -p "Confirm vx-vendor password: " CONFIRM_PASSWORD

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -542,6 +542,15 @@ fi
 # NOTE: This behavior changes in v11 and will require another update
 grep 'manage-package-manager-versions=false' /vx/code/vxsuite/.npmrc > /dev/null 2>&1 || echo 'manage-package-manager-versions=false' >> /vx/code/vxsuite/.npmrc
 
+# pnpm 10 also verifies node_modules against the lockfile before running any
+# script and attempts a `pnpm install` when they differ. /vx/code is read-only
+# at runtime and there is no network, so the install fails with EACCES and the
+# app does not start. This setting lives in pnpm-workspace.yaml, which takes
+# precedence over .npmrc in pnpm 10, so it has to be patched there.
+if grep -q '^verifyDepsBeforeRun:' /vx/code/vxsuite/pnpm-workspace.yaml 2>/dev/null; then
+    sudo sed -i 's/^verifyDepsBeforeRun:.*/verifyDepsBeforeRun: false/' /vx/code/vxsuite/pnpm-workspace.yaml
+fi
+
 # Set up a one-time run to wipe the vx user directory
 sudo cp config/vx-cleanup.service /etc/systemd/system/
 sudo cp config/vx-cleanup.sh /var/opt/vx-cleanup.sh


### PR DESCRIPTION
Necessary changes to support scripted builds. Some commits duplicated from other PRs for testing purposes. Notably updates setup-machine to take all CLI args instead of interactive prompts, prompts are still given if the new args are not passed through. Also allows an option to skip the final reboot because the script has its own final cleanup step that will schedule this shutdown. Cleanups up ssh-server. 