### PR TITLE
Copy/symlink Playwright Chromium to expected path

### DIFF
--- a/run-scripts/run-admin.sh
+++ b/run-scripts/run-admin.sh
@@ -16,6 +16,7 @@ if [ -z "${ADMIN_WORKSPACE:-}" ]; then
   exit 1
 fi
 
-export PIPENV_VENV_IN_PROJECT=1
 export NODE_ENV=production
+export PIPENV_VENV_IN_PROJECT=1
+export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=1
 (trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/admin/backend run & make -C vxsuite/services/converter-ms-sems run & make -C vxsuite/apps/admin/frontend run) | logger -S 4096 --tag votingworksapp

--- a/run-scripts/run-central-scan.sh
+++ b/run-scripts/run-central-scan.sh
@@ -16,6 +16,7 @@ if [ -z "${SCAN_WORKSPACE:-}" ]; then
   exit 1
 fi
 
-export PIPENV_VENV_IN_PROJECT=1
 export NODE_ENV=production
+export PIPENV_VENV_IN_PROJECT=1
+export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=1
 (trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/central-scan/backend run & make -C vxsuite/apps/central-scan/frontend run) | logger -S 4096 --tag votingworksapp

--- a/run-scripts/run-mark-scan.sh
+++ b/run-scripts/run-mark-scan.sh
@@ -11,6 +11,7 @@ CONFIG=${VX_CONFIG_ROOT:-./config}
 METADATA=${VX_METADATA_ROOT:-./}
 source ${CONFIG}/read-vx-machine-config.sh
 
-export PIPENV_VENV_IN_PROJECT=1
 export NODE_ENV=production
+export PIPENV_VENV_IN_PROJECT=1
+export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=1
 (trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/mark-scan/backend run & make -C vxsuite/apps/mark-scan/frontend run) | logger -S 4096 --tag votingworksapp

--- a/run-scripts/run-mark.sh
+++ b/run-scripts/run-mark.sh
@@ -11,6 +11,7 @@ CONFIG=${VX_CONFIG_ROOT:-./config}
 METADATA=${VX_METADATA_ROOT:-./}
 source ${CONFIG}/read-vx-machine-config.sh
 
-export PIPENV_VENV_IN_PROJECT=1
 export NODE_ENV=production
+export PIPENV_VENV_IN_PROJECT=1
+export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=1
 (trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/mark/backend run & make -C vxsuite/apps/mark/frontend run) | logger -S 4096 --tag votingworksapp

--- a/run-scripts/run-print.sh
+++ b/run-scripts/run-print.sh
@@ -16,6 +16,7 @@ if [ -z "${PRINT_WORKSPACE:-}" ]; then
   exit 1
 fi
 
-export PIPENV_VENV_IN_PROJECT=1
 export NODE_ENV=production
+export PIPENV_VENV_IN_PROJECT=1
+export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=1
 (trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/print/backend run & make -C vxsuite/apps/print/frontend run) | logger -S 4096 --tag votingworksapp

--- a/run-scripts/run-scan.sh
+++ b/run-scripts/run-scan.sh
@@ -16,6 +16,7 @@ if [ -z "${SCAN_WORKSPACE:-}" ]; then
   exit 1
 fi
 
-export PIPENV_VENV_IN_PROJECT=1
 export NODE_ENV=production
+export PIPENV_VENV_IN_PROJECT=1
+export PLAYWRIGHT_SKIP_VALIDATE_HOST_REQUIREMENTS=1
 (trap 'kill 0' SIGINT SIGHUP; make -C vxsuite/apps/scan/backend run & make -C vxsuite/apps/scan/frontend run) | logger -S 4096 --tag votingworksapp

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -188,8 +188,10 @@ sudo ln -s /vx/code/run-${CHOICE}.sh /vx/services/run-${CHOICE}.sh
 # Copy and symlink Playwright Chromium to the path that Playwright will expect when run as
 # vx-services
 sudo cp -rp ~/.cache/ms-playwright /vx/code/
+sudo cp -rp ~/.cache/vx-playwright-deps /vx/code/
 sudo mkdir -p /vx/services/.cache
 sudo ln -s /vx/code/ms-playwright /vx/services/.cache/ms-playwright
+sudo ln -s /vx/code/vx-playwright-deps /vx/services/.cache/vx-playwright-deps
 
 # symlink appropriate vx/ui files
 sudo ln -s /vx/code/config/Xresources /vx/ui/.Xresources

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -185,6 +185,12 @@ sudo cp -rp vxsuite /vx/code/
 sudo ln -s /vx/code/vxsuite /vx/services/vxsuite
 sudo ln -s /vx/code/run-${CHOICE}.sh /vx/services/run-${CHOICE}.sh
 
+# Copy and symlink Playwright Chromium to the path that Playwright will expect when run as
+# vx-services
+sudo cp -rp ~/.cache/ms-playwright /vx/code/
+sudo mkdir -p /vx/services/.cache
+sudo ln -s /vx/code/ms-playwright /vx/services/.cache/ms-playwright
+
 # symlink appropriate vx/ui files
 sudo ln -s /vx/code/config/Xresources /vx/ui/.Xresources
 sudo ln -s /vx/code/config/Xmodmap /vx/ui/.Xmodmap


### PR DESCRIPTION
## Overview

After merging https://github.com/votingworks/vxsuite/pull/9191, we're seeing the following error when trying to print on a QA image:

> Executable doesn't exist at /var/vx/services/.cache/ms-playwright/chromium_headless_shell-1193/chrome-linux/headless_shell

The issue here is that Playwright is installing Chromium in the vx user's home directory whereas, at runtime, we're looking for it in the vx-services user's home directory. The vx user and corresponding home directory are also completely removed by the end of image creation. To remedy this, I'm copying and symlinking Chromium to the expected path.

## Testing

- [x] Tested via an image