### PR TITLE
Ensure that VxMark HWTA headphone volume setting is respected

### DIFF
--- a/config/xinitrc
+++ b/config/xinitrc
@@ -59,10 +59,12 @@ pactl unload-module module-suspend-on-idle
 # (because of course they do)
 #
 # NOTE: On VxMark, the startup chime is played through the speakers from within
-# the app server, so we instead play a shortned version here through the
+# the app server, so we instead play a shortened version here through the
 # headphones, to activate the headphone audio device.
 if cat $VX_CONFIG_ROOT/machine-type | grep "^mark$" > /dev/null; then
-  sleep 2 && aplay ~/chime-short.wav && pactl set-sink-volume 0 100%
+  # On VxMark, the app server owns volume setting so don't set anything here
+  # that might conflict
+  sleep 2 && aplay ~/chime-short.wav
 else
   sleep 5 && aplay ~/chime.wav && pactl set-sink-volume 0 100%
 fi


### PR DESCRIPTION
## Overview

Closes https://github.com/votingworks/vxsuite/issues/9085

The VxMark HWTA headphone volume is currently extremely loud despite the HWTA backend setting the headphone volume to 40%. This appears to be because it's being overridden by a 100% volume set in the xinitrc, which runs with a sleep so happens after the app-level set and takes precedence. The xinitrc 100% volume set isn't needed for the main app either. On VxMark, the app server owns volume setting, setting to 100% for the main app and 40% for the HWTA. The main app uses gain to ensure audio isn't blaringly loud.

## Testing

Tested by patching a QA image and confirming that this does the trick