### PR TITLE
Update setup-machine.sh to reflect no longer using vxsuite submodules

### DIFF
--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -171,6 +171,7 @@ then
 fi
 
 echo "Setting up the code"
+pushd /home/vx/code/vxsuite
 sudo rsync -avz build/${CHOICE}/ /vx/code/
 
 # temporary hack cause of precinct-scanner runtime issue
@@ -178,8 +179,9 @@ sudo rsync -avz build/${CHOICE}/ /vx/code/
 sudo rm /vx/code/vxsuite # it's a symlink
 # We have limited space on the root partition so don't copy over the unneeded VxDesign and
 # VxPollBook directories
-rm -r vxsuite/apps/design vxsuite/apps/pollbook
-sudo cp -rp vxsuite /vx/code/
+rm -r apps/design apps/pollbook
+sudo cp -rp . /vx/code/vxsuite
+popd
 
 # symlink the code and run-*.sh in /vx/services
 sudo ln -s /vx/code/vxsuite /vx/services/vxsuite


### PR DESCRIPTION
This PR updates the setup-machine.sh process to correctly copy the vxsuite code in the new directory structure that does not use submodules.