### PR TITLE
initial change to support ipp-usb with avahi networking purged/disabled

### DIFF
--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -349,8 +349,12 @@ else
   # remove network packages
   sudo apt purge -y network-manager iw > /dev/null 2>&1 || true
 
-  # remove avahi packages
-  sudo apt purge -y avahi-daemon avahi-utils avahi-autoipd > /dev/null 2>&1 || true
+  # remove most avahi packages
+  # Note: the avahi-daemon package remains because it is a dependency for
+  # ipp-usb. As a result, we explicitly disable related services
+  sudo apt purge -y avahi-utils avahi-autoipd > /dev/null 2>&1 || true
+  sudo systemctl disable --now avahi-daemon.service avahi-daemon.socket
+  sudo systemctl mask avahi-daemon.service avahi-daemon.socket
 
   # remove strongswan packages
   sudo apt purge -y strongswan-ctl libstrongswan-extra-plugins libstrongswan-standard-plugins charon-systemd strongswan-pki > /dev/null 2>&1 || true


### PR DESCRIPTION
This PR supports rich printer status/function (via the `ipp-usb` package) while also disabling unnecessary networking functionality on machine types that do not use it, e.g. VxMark.

Because we install the `avahi-daemon` package in our base VM build, the `apt purge` command that removed all `avahi-*` packages also removed the `ipp-usb` package. Rather than overly complicate the build process, this change still removes `avahi-*` packages, with the exception of `avahi-daemon`. Since that package remains, we need to ensure that service does not run, so we use standard `systemctl` commands to disable the related service and socket and prevent it from being re-enabled.

To test, I built a new image, created a VxMark app from it, validated the Diagnostics page correctly showed the printer status and toner level, along with successfully printing a test page.

This will close https://github.com/votingworks/vxsuite/issues/9189