### PR TITLE
Include central-scan in optional networking image support

### DIFF
--- a/config/vendor-functions/basic-configuration.sh
+++ b/config/vendor-functions/basic-configuration.sh
@@ -43,7 +43,7 @@ if [[ "${VX_MACHINE_TYPE}" = "admin" || "${VX_MACHINE_TYPE}" = "poll-book" ]]; t
     sudo ${VX_FUNCTIONS_ROOT}/program-system-administrator-cards.sh
 fi
 
-if [[ "${VX_MACHINE_TYPE}" = "admin" ]]; then
+if [[ "${VX_MACHINE_TYPE}" = "admin" || "${VX_MACHINE_TYPE}" = "central-scan" ]]; then
     echo
     echo -e "\e[1mStep 6: Network Configuration\e[0m"
     read -p "Should local networking be enabled? (y/n) " NETWORK_ENABLED

--- a/config/vendor-functions/create-machine-cert.sh
+++ b/config/vendor-functions/create-machine-cert.sh
@@ -23,7 +23,7 @@ else
     MACHINE_CERT_PATH="${VX_CONFIG_ROOT}/vx-${VX_MACHINE_TYPE}-cert.pem"
 fi
 
-if [[ "${VX_MACHINE_TYPE}" == "admin" || "${VX_MACHINE_TYPE}" == "poll-book" ]]; then
+if [[ "${VX_MACHINE_TYPE}" == "admin" || "${VX_MACHINE_TYPE}" == "poll-book" || "${VX_MACHINE_TYPE}" == "central-scan" ]]; then
     USB_DRIVE_STRONGSWAN_CSR_PATH="${USB_DRIVE_CERTS_DIRECTORY}/csr-${VX_MACHINE_ID}-strongswan.pem"
     USB_DRIVE_STRONGSWAN_CERT_PATH="${USB_DRIVE_CERTS_DIRECTORY}/cert-${VX_MACHINE_ID}-strongswan.pem"
     MACHINE_STRONGSWAN_CERT_PATH="/etc/swanctl/x509/vx-${VX_MACHINE_TYPE}-strongswan-rsa-cert.pem"
@@ -44,7 +44,7 @@ function unmount_usb_drive() {
 function clean_up_usb_drive() {
     mkdir -p "${USB_DRIVE_CERTS_DIRECTORY}"
     rm -rf "${USB_DRIVE_CSR_PATH}" "${USB_DRIVE_CERT_PATH}"
-    if [[ "${VX_MACHINE_TYPE}" == "admin" || "${VX_MACHINE_TYPE}" == "poll-book" ]]; then
+    if [[ "${VX_MACHINE_TYPE}" == "admin" || "${VX_MACHINE_TYPE}" == "poll-book" || "${VX_MACHINE_TYPE}" == "central-scan" ]]; then
         rm -rf "${USB_DRIVE_STRONGSWAN_CSR_PATH}" "${USB_DRIVE_STRONGSWAN_CERT_PATH}"
     fi
 }
@@ -88,6 +88,7 @@ function create_machine_cert_signing_request() {
     else
         VX_MACHINE_TYPE="${VX_MACHINE_TYPE}" \
             VX_MACHINE_ID="${VX_MACHINE_ID}" \
+            USE_STRONGSWAN_TPM_KEY="${USE_STRONGSWAN_TPM_KEY}" \
             ./create-production-machine-cert-signing-request
     fi
     popd > /dev/null
@@ -111,10 +112,11 @@ else
     create_machine_cert_signing_request > "${USB_DRIVE_CSR_PATH}"
 fi
 
-# VxAdmin and VxPollBooks need an additional cert for strongSwan using a different TPM handle
-if [[ "${VX_MACHINE_TYPE}" == "admin" || "${VX_MACHINE_TYPE}" == "poll-book" ]]; then
+# Networked machine types (VxAdmin, VxPollBook, VxCentralScan) need an additional cert for
+# strongSwan using a different TPM handle
+if [[ "${VX_MACHINE_TYPE}" == "admin" || "${VX_MACHINE_TYPE}" == "poll-book" || "${VX_MACHINE_TYPE}" == "central-scan" ]]; then
     USE_STRONGSWAN_TPM_KEY="1"
-    create_machine_cert_signing_request "${MACHINE_JURISDICTION}" > "${USB_DRIVE_STRONGSWAN_CSR_PATH}"
+    create_machine_cert_signing_request "${MACHINE_JURISDICTION:-}" > "${USB_DRIVE_STRONGSWAN_CSR_PATH}"
 fi
 
 unmount_usb_drive
@@ -153,7 +155,7 @@ echo "Copying cert to ${MACHINE_CERT_PATH}..."
 cp "${USB_DRIVE_CERT_PATH}" "${MACHINE_CERT_PATH}"
 match_vx_config_non_executable_file_permissions "${MACHINE_CERT_PATH}"
 
-if [[ "${VX_MACHINE_TYPE}" == "admin" || "${VX_MACHINE_TYPE}" == "poll-book" ]]; then
+if [[ "${VX_MACHINE_TYPE}" == "admin" || "${VX_MACHINE_TYPE}" == "poll-book" || "${VX_MACHINE_TYPE}" == "central-scan" ]]; then
   echo "Copying strongSwan cert to ${MACHINE_STRONGSWAN_CERT_PATH}..."
   cp "${USB_DRIVE_STRONGSWAN_CERT_PATH}" "${MACHINE_STRONGSWAN_CERT_PATH}"
   cp "${ROOT_VX_CERT_AUTHORITY_CERT_PATH}" /etc/swanctl/x509ca/vx-cert-authority-cert.pem
@@ -205,7 +207,7 @@ check_cert_signed_by_correct_cert_authority \
     "${MACHINE_CERT_PATH}" \
     "${ROOT_VX_CERT_AUTHORITY_CERT_PATH}"
 
-if [[ "${VX_MACHINE_TYPE}" == "admin" || "${VX_MACHINE_TYPE}" == "poll-book" ]]; then
+if [[ "${VX_MACHINE_TYPE}" == "admin" || "${VX_MACHINE_TYPE}" == "poll-book" || "${VX_MACHINE_TYPE}" == "central-scan" ]]; then
     check_cert_contains_correct_public_key \
         "${MACHINE_STRONGSWAN_CERT_PATH}" \
         "${VX_CONFIG_ROOT}/vx-${VX_MACHINE_TYPE}-strongswan-rsa-cert.pub"

--- a/config/vendor-functions/generate-key.sh
+++ b/config/vendor-functions/generate-key.sh
@@ -48,15 +48,13 @@ tpm2_readpublic -c key.ctx -f PEM -o "${VX_CONFIG_ROOT}/key.pub"
 
 chmod +r "${VX_CONFIG_ROOT}/key.pub"
 
-# TODO: hacking for initial testing of admin machines with networking
-#
-# poll-book machines require the creation of endorsement and
-# attestation keys used by strongswan for tpm authentication
+# Networked machine types (admin, poll-book, central-scan) require the creation
+# of endorsement and attestation keys used by strongswan for tpm authentication
 machine_type=$(cat ${VX_CONFIG_ROOT}/machine-type 2>/dev/null)
-if [[ "${machine_type}" == "admin" || "${machine_type}" == "poll-book" ]]; then
+if [[ "${machine_type}" == "admin" || "${machine_type}" == "poll-book" || "${machine_type}" == "central-scan" ]]; then
   ek_handle="0x81000003"
   ak_handle="0x81010003"
-  echo "Setting up TPM keys for admin/pollbook..."
+  echo "Setting up TPM keys for ${machine_type} networking..."
   # First, create a persistent RSA endorsement key
   tpm2_evictcontrol -Q -c "${ek_handle}" &> /dev/null || true
   tpm2_createek -G rsa -c "${ek_handle}"

--- a/config/vendor-functions/show-vendor-menu.sh
+++ b/config/vendor-functions/show-vendor-menu.sh
@@ -51,7 +51,7 @@ while true; do
     echo -e "Secure Boot State: \e[31mDisabled\e[0m"
   fi
 
-  if [[ "${VX_MACHINE_TYPE}" = "admin" ]]; then
+  if [[ "${VX_MACHINE_TYPE}" = "admin" || "${VX_MACHINE_TYPE}" = "central-scan" ]]; then
     NETWORK_STATE=$(cat ${VX_CONFIG_ROOT}/local-ethernet-state 2>/dev/null || echo disable)
     if [[ "${NETWORK_STATE}" = "enable" ]]; then
       echo -e "Local Network State: \e[32mEnabled\e[0m"
@@ -127,7 +127,7 @@ while true; do
     CHOICES+=('program-system-administrator-cards')
   fi
 
-  if [[ "${VX_MACHINE_TYPE}" = "admin" ]]; then
+  if [[ "${VX_MACHINE_TYPE}" = "admin" || "${VX_MACHINE_TYPE}" = "central-scan" ]]; then
     echo "${#CHOICES[@]}. Toggle Local Network State"
     CHOICES+=('toggle-local-network-state')
   fi

--- a/setup-machine.sh
+++ b/setup-machine.sh
@@ -333,12 +333,16 @@ sudo rm -f /etc/localtime
 sudo ln -sf /usr/share/zoneinfo/America/Chicago /vx/config/localtime
 sudo ln -sf /vx/config/localtime /etc/localtime
 
-# admin types now have support for limited local ethernet
+# admin and central-scan types have support for limited local ethernet
 # set up various paths for config persistence and secure boot
-if [[ "${CHOICE}" == "admin" ]]; then
+if [[ "${CHOICE}" == "admin" || "${CHOICE}" == "central-scan" ]]; then
   sudo mkdir -p /vx/config/etc
   sudo mv /etc/swanctl/ /vx/config/etc/
   sudo ln -fs /vx/config/etc/swanctl /etc/swanctl
+
+  # the build-system ships one strongswan config for every machine type; point
+  # it at the strongswan cert this machine type creates (see create-machine-cert.sh)
+  sudo sed -i "s/@VX_MACHINE_TYPE@/${CHOICE}/g" /etc/swanctl/conf.d/vxswan.conf
   sudo cp config/apparmor.d/usr.sbin.swanctl /etc/apparmor.d/
 
   # Note: this does not enable local ethernet connections


### PR DESCRIPTION
Not yet tested. In general just adds a "or central-scan" to all of the networking checks. The one slight complication is making sure the name of the strongswan cert is correct and that the vxswan conf file is expecting the right name. 